### PR TITLE
게시글쓰기 화면에서 목록으로 이동할때 오류 수정

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/cop/bbs/EgovNoticeRegist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cop/bbs/EgovNoticeRegist.jsp
@@ -57,9 +57,9 @@
     }
     
     function fn_egov_select_noticeList() {
-        document.board.action = "<c:url value='/cop/bbs${prefix}/selectBoardList.do'/>"+ "?bbsId=" +"<c:out value='${bdMstr.bbsId}'/>";
+        document.board.action = "<c:url value='/cop/bbs${prefix}/selectBoardList.do'/>";
         document.board.submit();
-    }   
+    }
 </script>
 <style type="text/css">
 .noStyle {background:ButtonFace; BORDER-TOP:0px; BORDER-bottom:0px; BORDER-left:0px; BORDER-right:0px;}


### PR DESCRIPTION
게시글쓰기 화면에서 목록으로 이동할때 오류가 발생합니다.

이 오류는 bbsId 파라미터가 쿼리스트링과 form input으로 중복 설정 되었고,
이 때 서버에서는 콤마 기준으로 중복된 값을 모두 표출하게 됩니다.

쿼리스트링 부분을 수정하여 PR하였으니 참고해주세요.

감사합니다.