### PR TITLE
[chore] Add Dependabot configuration for Maven and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 3
+    labels:
+      - "ci"
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
## 변경 사유
현재 `.github/dependabot.yml` 미설치로 의존성 버전 관리가 수동으로 이루어지고 있어 보안 패치 누락 위험이 있습니다. 자동화된 의존성 업데이트 PR을 받을 수 있도록 Dependabot을 활성화합니다.

## 변경 내용
- `.github/dependabot.yml` 신규 추가
  - maven ecosystem: 주간 스캔, 동시 PR 5개 제한
  - github-actions ecosystem: 주간 스캔, 동시 PR 3개 제한
  - 라벨: dependencies / ci
  - 스케줄: 매주 월요일 09:00 KST

## 영향 범위
- 기존 코드/빌드/테스트 영향 없음
- 머지 후 첫 월요일에 Dependabot이 의존성 스캔 시작

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 5.0.x 브랜치 대상
- [x] 기존 동작에 영향 없음
- [x] CI에 영향 없음 (워크플로 자체는 미변경)