### PR TITLE
[chore] CI 워크플로 5.0.x 브랜치 트리거 추가 및 deprecated actions 업그레이드

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,9 +2,9 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ "main", "5.0.x" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "5.0.x" ]
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,9 +2,9 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "5.0.x" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "5.0.x" ]
 
 jobs:
   build:
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'


### PR DESCRIPTION
## 변경 사유
현재 `.github/workflows/maven.yml`는 `main` 브랜치만 트리거하고 있어 5.0.x 대상 PR이 CI에서 검증되지 않습니다. 또한 `actions/checkout@v3`/`setup-java@v3`는 end-of-support 상태입니다.

## 변경 내용
- `push.branches`, `pull_request.branches`에 `"5.0.x"` 추가
- `actions/checkout@v3` → `@v4`
- `actions/setup-java@v3` → `@v4`

## 영향 범위
- 빌드 명령 동일 (`mvn -B package --file pom.xml -Dmaven.test.skip=true`)
- 머지 후 5.0.x 대상 push/PR이 CI에서 자동 빌드됨

## 체크리스트
- [x] 단일 주제(CI 인프라 갱신)
- [x] 5.0.x 브랜치 대상
- [x] 빌드 명령 미변경