### PR TITLE
[feat] Dockerfile, docker-compose, Kubernetes 매니페스트 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+target/
+*.log
+.idea/
+.vscode/
+.git/
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml
+k8s/
+README*.md
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for egovframe-simple-homepage-template.
+# Stage 1 builds the war with Maven.
+# Stage 2 serves it from Tomcat 10.1 on Temurin JRE 17.
+
+# ---------- Build ----------
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /workspace
+
+COPY pom.xml ./
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp dependency:go-offline
+
+COPY src ./src
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp -DskipTests package && \
+    cp target/*.war /workspace/ROOT.war
+
+# ---------- Runtime ----------
+FROM tomcat:10.1-jre17
+
+# Drop the default ROOT and replace with our war
+RUN rm -rf /usr/local/tomcat/webapps/ROOT
+COPY --from=build /workspace/ROOT.war /usr/local/tomcat/webapps/ROOT.war
+
+ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=70 -XX:+ExitOnOutOfMemoryError"
+
+EXPOSE 8080
+
+CMD ["catalina.sh","run"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  app:
+    build: .
+    image: egovframe-simple-homepage-template:${APP_VERSION:-5.0.0}
+    container_name: egov-simple-homepage
+    ports:
+      - "8080:8080"
+    restart: unless-stopped

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,151 @@
+# Kubernetes 운영 가이드
+
+egovframe-simple-homepage-template 애플리케이션을 Kubernetes 클러스터에 배포하고 운영하는 절차를 설명합니다.
+
+## 매니페스트 구성
+
+| 파일 | 설명 |
+|------|------|
+| `deployment.yaml` | Deployment (replicas: 1, RollingUpdate, readiness/liveness 프로브 포함) |
+| `service.yaml` | Service (ClusterIP, 포트 8080) |
+
+---
+
+## 1. 빌드 및 이미지 생성
+
+프로젝트 루트에서 Docker 이미지를 빌드합니다.
+
+```bash
+# 프로젝트 루트로 이동
+cd egovframe-simple-homepage-template
+
+# Docker 이미지 빌드
+docker build -t egovframe-simple-homepage-template:5.0.0 .
+
+# (선택) 레지스트리에 푸시할 경우 태그 추가
+docker tag egovframe-simple-homepage-template:5.0.0 \
+  ghcr.io/<org>/egovframe-simple-homepage-template:5.0.0
+
+docker push ghcr.io/<org>/egovframe-simple-homepage-template:5.0.0
+```
+
+> 레지스트리를 사용할 경우 `k8s/deployment.yaml`의 `image` 필드를 실제 레지스트리 주소로 변경합니다.
+
+---
+
+## 2. 배포
+
+```bash
+# 매니페스트 일괄 적용
+kubectl apply -f k8s/
+
+# 또는 파일별 순서대로 적용
+kubectl apply -f k8s/deployment.yaml
+kubectl apply -f k8s/service.yaml
+```
+
+---
+
+## 3. 배포 상태 확인
+
+```bash
+# Deployment 롤아웃 완료 대기
+kubectl rollout status deployment/egov-simple-homepage
+
+# Pod 목록 확인 (STATUS: Running 확인)
+kubectl get pods -l app.kubernetes.io/name=egov-simple-homepage
+
+# Pod 상세 정보 (이벤트, probe 상태 포함)
+kubectl describe pod -l app.kubernetes.io/name=egov-simple-homepage
+
+# Service 확인
+kubectl get service egov-simple-homepage
+```
+
+---
+
+## 4. 접속
+
+### ClusterIP (기본) — 클러스터 내부에서 접근
+
+```
+http://egov-simple-homepage:8080
+```
+
+### kubectl port-forward — 로컬 PC에서 직접 접근
+
+```bash
+kubectl port-forward service/egov-simple-homepage 8080:8080
+```
+
+브라우저에서 `http://localhost:8080` 으로 접속합니다.
+
+### minikube — minikube 환경
+
+```bash
+# NodePort로 Service 타입 변경 후 접근
+kubectl patch service egov-simple-homepage \
+  -p '{"spec": {"type": "NodePort"}}'
+
+minikube service egov-simple-homepage --url
+```
+
+출력된 URL로 브라우저에서 접속합니다.
+
+---
+
+## 5. 로그 확인
+
+```bash
+# 실시간 로그 스트리밍
+kubectl logs -f deployment/egov-simple-homepage
+
+# 이전 컨테이너 로그 (재시작된 경우)
+kubectl logs deployment/egov-simple-homepage --previous
+```
+
+---
+
+## 6. 스케일 조정
+
+```bash
+# 레플리카 수 조정
+kubectl scale deployment egov-simple-homepage --replicas=3
+
+# 오토스케일링 (HPA)
+kubectl autoscale deployment egov-simple-homepage \
+  --cpu-percent=70 --min=1 --max=5
+```
+
+---
+
+## 7. 업데이트 및 롤백
+
+```bash
+# 이미지 업데이트 (새 버전 배포)
+kubectl set image deployment/egov-simple-homepage \
+  app=egovframe-simple-homepage-template:5.0.1
+
+# 롤아웃 이력 확인
+kubectl rollout history deployment/egov-simple-homepage
+
+# 이전 버전으로 롤백
+kubectl rollout undo deployment/egov-simple-homepage
+```
+
+---
+
+## 8. 리소스 정리
+
+```bash
+kubectl delete -f k8s/
+```
+
+---
+
+## 참고
+
+- 컨테이너 포트: **8080** (HTTP)
+- Readiness 프로브: `GET /` (초기 대기 30초, 10초 간격, 6회 실패 시 트래픽 차단)
+- Liveness 프로브: `GET /` (초기 대기 90초, 20초 간격, 3회 실패 시 컨테이너 재시작)
+- 보안 컨텍스트: 비루트(UID 1000) 실행, 권한 상승 비허용

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: egov-simple-homepage
+  labels:
+    app.kubernetes.io/name: egov-simple-homepage
+    app.kubernetes.io/part-of: egovframe-template
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: egov-simple-homepage
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: egov-simple-homepage
+        app.kubernetes.io/part-of: egovframe-template
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: app
+          # Replace with your registry/tag, e.g. ghcr.io/<org>/egov-simple-homepage:5.0.0
+          image: egovframe-simple-homepage-template:5.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 20
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tomcat-work
+              mountPath: /usr/local/tomcat/work
+            - name: tomcat-temp
+              mountPath: /usr/local/tomcat/temp
+            - name: tomcat-logs
+              mountPath: /usr/local/tomcat/logs
+      volumes:
+        - name: tomcat-work
+          emptyDir: {}
+        - name: tomcat-temp
+          emptyDir: {}
+        - name: tomcat-logs
+          emptyDir: {}

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: egov-simple-homepage
+  labels:
+    app.kubernetes.io/name: egov-simple-homepage
+    app.kubernetes.io/part-of: egovframe-template
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: egov-simple-homepage
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http


### PR DESCRIPTION
## 변경 사유
컨테이너 이미지/k8s 매니페스트가 없어 로컬 실행만 가능합니다. `tomcat:10.1-jre17` 기반의 최소 산출물을 추가합니다.

## 변경 내용
- `Dockerfile` — multi-stage `maven:3.9-eclipse-temurin-17` → `tomcat:10.1-jre17`, 기본 ROOT 앱 제거 후 war를 ROOT.war로 배치
- `.dockerignore` — 빌드 컨텍스트 축소
- `docker-compose.yml` — 단일 서비스, `${APP_VERSION:-5.0.0}` 변수화
- `k8s/deployment.yaml` — 1 replica RollingUpdate, runAsNonRoot, drop ALL, resource requests/limits, liveness/readiness probe(/)
- `k8s/service.yaml` — ClusterIP 8080

## 영향 범위
- 애플리케이션 코드 변경 없음
- `image:` 태그는 예시 — 운영 환경 레지스트리로 교체 필요

## 체크리스트
- [x] 단일 주제(컨테이너화 + k8s 매니페스트)
- [x] 5.0.x 브랜치 대상
- [x] 기존 코드 미변경