### PR TITLE
[refactor] 핵심 VO에 Lombok @Getter/@Setter 적용

### DIFF
--- a/src/main/java/egovframework/com/cmm/ComDefaultCodeVO.java
+++ b/src/main/java/egovframework/com/cmm/ComDefaultCodeVO.java
@@ -2,6 +2,9 @@ package egovframework.com.cmm;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
@@ -20,6 +23,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * </pre>
  */
+@Getter
+@Setter
 public class ComDefaultCodeVO implements Serializable {
     /**
 	 *  serialVersion UID
@@ -28,157 +33,24 @@ public class ComDefaultCodeVO implements Serializable {
 
 	/** 코드 ID */
     private String codeId = "";
-    
+
     /** 상세코드 */
     private String code = "";
-    
+
     /** 코드명 */
     private String codeNm = "";
-    
+
     /** 코드설명 */
     private String codeDc = "";
-    
+
     /** 특정테이블명 */
     private String tableNm = "";	//특정테이블에서 코드정보를추출시 사용
-    
+
     /** 상세 조건 여부 */
     private String haveDetailCondition = "N";
-    
+
     /** 상세 조건 */
     private String detailCondition = "";
-    
-    /**
-     * codeId attribute를 리턴한다.
-     * 
-     * @return the codeId
-     */
-    public String getCodeId() {
-	return codeId;
-    }
-
-    /**
-     * codeId attribute 값을 설정한다.
-     * 
-     * @param codeId
-     *            the codeId to set
-     */
-    public void setCodeId(String codeId) {
-	this.codeId = codeId;
-    }
-
-    /**
-     * code attribute를 리턴한다.
-     * 
-     * @return the code
-     */
-    public String getCode() {
-	return code;
-    }
-
-    /**
-     * code attribute 값을 설정한다.
-     * 
-     * @param code
-     *            the code to set
-     */
-    public void setCode(String code) {
-	this.code = code;
-    }
-
-    /**
-     * codeNm attribute를 리턴한다.
-     * 
-     * @return the codeNm
-     */
-    public String getCodeNm() {
-	return codeNm;
-    }
-
-    /**
-     * codeNm attribute 값을 설정한다.
-     * 
-     * @param codeNm
-     *            the codeNm to set
-     */
-    public void setCodeNm(String codeNm) {
-	this.codeNm = codeNm;
-    }
-
-    /**
-     * codeDc attribute를 리턴한다.
-     * 
-     * @return the codeDc
-     */
-    public String getCodeDc() {
-	return codeDc;
-    }
-
-    /**
-     * codeDc attribute 값을 설정한다.
-     * 
-     * @param codeDc
-     *            the codeDc to set
-     */
-    public void setCodeDc(String codeDc) {
-	this.codeDc = codeDc;
-    }
-
-    /**
-     * tableNm attribute를 리턴한다.
-     * 
-     * @return the tableNm
-     */
-    public String getTableNm() {
-	return tableNm;
-    }
-
-    /**
-     * tableNm attribute 값을 설정한다.
-     * 
-     * @param tableNm
-     *            the tableNm to set
-     */
-    public void setTableNm(String tableNm) {
-	this.tableNm = tableNm;
-    }
-
-    /**
-     * haveDetailCondition attribute를 리턴한다.
-     * 
-     * @return the haveDetailCondition
-     */
-    public String getHaveDetailCondition() {
-	return haveDetailCondition;
-    }
-
-    /**
-     * haveDetailCondition attribute 값을 설정한다.
-     * 
-     * @param haveDetailCondition
-     *            the haveDetailCondition to set
-     */
-    public void setHaveDetailCondition(String haveDetailCondition) {
-	this.haveDetailCondition = haveDetailCondition;
-    }
-
-    /**
-     * detailCondition attribute를 리턴한다.
-     * 
-     * @return the detailCondition
-     */
-    public String getDetailCondition() {
-	return detailCondition;
-    }
-
-    /**
-     * detailCondition attribute 값을 설정한다.
-     * 
-     * @param detailCondition
-     *            the detailCondition to set
-     */
-    public void setDetailCondition(String detailCondition) {
-	this.detailCondition = detailCondition;
-    }
 
     /**
      * toString 메소드를 대치한다.

--- a/src/main/java/egovframework/com/cmm/ComDefaultVO.java
+++ b/src/main/java/egovframework/com/cmm/ComDefaultVO.java
@@ -2,6 +2,9 @@ package egovframework.com.cmm;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
@@ -19,6 +22,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *  @see
  *
  */
+@Getter
+@Setter
 public class ComDefaultVO implements Serializable {
 
 	private static final long serialVersionUID = -6062858939907510631L;
@@ -56,113 +61,9 @@ public class ComDefaultVO implements Serializable {
 	/** 검색KeywordTo */
     private String searchKeywordTo = "";
 
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-
-	public String getSearchCondition() {
-        return searchCondition;
-    }
-
-    public void setSearchCondition(String searchCondition) {
-        this.searchCondition = searchCondition;
-    }
-
-    public String getSearchKeyword() {
-        return searchKeyword;
-    }
-
-    public void setSearchKeyword(String searchKeyword) {
-        this.searchKeyword = searchKeyword;
-    }
-
-    public String getSearchUseYn() {
-        return searchUseYn;
-    }
-
-    public void setSearchUseYn(String searchUseYn) {
-        this.searchUseYn = searchUseYn;
-    }
-
-    public int getPageIndex() {
-        return pageIndex;
-    }
-
-    public void setPageIndex(int pageIndex) {
-        this.pageIndex = pageIndex;
-    }
-
-    public int getPageUnit() {
-        return pageUnit;
-    }
-
-    public void setPageUnit(int pageUnit) {
-        this.pageUnit = pageUnit;
-    }
-
-    public int getPageSize() {
-        return pageSize;
-    }
-
-    public void setPageSize(int pageSize) {
-        this.pageSize = pageSize;
-    }
-
     @Override
 	public String toString() {
         return ToStringBuilder.reflectionToString(this);
     }
 
-
-    /**
-	 * searchKeywordFrom attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeywordFrom() {
-		return searchKeywordFrom;
-	}
-
-	/**
-	 * searchKeywordFrom attribute 값을 설정한다.
-	 * @param searchKeywordFrom String
-	 */
-	public void setSearchKeywordFrom(String searchKeywordFrom) {
-		this.searchKeywordFrom = searchKeywordFrom;
-	}
-
-	/**
-	 * searchKeywordTo attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeywordTo() {
-		return searchKeywordTo;
-	}
-
-	/**
-	 * searchKeywordTo attribute 값을 설정한다.
-	 * @param searchKeywordTo String
-	 */
-	public void setSearchKeywordTo(String searchKeywordTo) {
-		this.searchKeywordTo = searchKeywordTo;
-	}
 }

--- a/src/main/java/egovframework/com/cmm/LoginVO.java
+++ b/src/main/java/egovframework/com/cmm/LoginVO.java
@@ -2,6 +2,9 @@ package egovframework.com.cmm;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * @Class Name : LoginVO.java
  * @Description : Login VO class
@@ -15,15 +18,17 @@ import java.io.Serializable;
  *  @since 2009.03.03
  *  @version 1.0
  *  @see
- *  
+ *
  */
+@Getter
+@Setter
 public class LoginVO implements Serializable{
-	
+
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = -8274004534207618049L;
-	
+
 	/** 아이디 */
 	private String id;
 	/** 이름 */
@@ -52,199 +57,5 @@ public class LoginVO implements Serializable{
 	private String ip;
 	/** GPKI인증 DN */
 	private String dn;
-	/**
-	 * id attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getId() {
-		return id;
-	}
-	/**
-	 * id attribute 값을 설정한다.
-	 * @param id String
-	 */
-	public void setId(String id) {
-		this.id = id;
-	}
-	/**
-	 * name attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getName() {
-		return name;
-	}
-	/**
-	 * name attribute 값을 설정한다.
-	 * @param name String
-	 */
-	public void setName(String name) {
-		this.name = name;
-	}
-	/**
-	 * ihidNum attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getIhidNum() {
-		return ihidNum;
-	}
-	/**
-	 * ihidNum attribute 값을 설정한다.
-	 * @param ihidNum String
-	 */
-	public void setIhidNum(String ihidNum) {
-		this.ihidNum = ihidNum;
-	}
-	/**
-	 * email attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getEmail() {
-		return email;
-	}
-	/**
-	 * email attribute 값을 설정한다.
-	 * @param email String
-	 */
-	public void setEmail(String email) {
-		this.email = email;
-	}
-	/**
-	 * password attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getPassword() {
-		return password;
-	}
-	/**
-	 * password attribute 값을 설정한다.
-	 * @param password String
-	 */
-	public void setPassword(String password) {
-		this.password = password;
-	}
-	/**
-	 * passwordHint attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getPasswordHint() {
-		return passwordHint;
-	}
-	/**
-	 * passwordHint attribute 값을 설정한다.
-	 * @param passwordHint String
-	 */
-	public void setPasswordHint(String passwordHint) {
-		this.passwordHint = passwordHint;
-	}
-	/**
-	 * passwordCnsr attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getPasswordCnsr() {
-		return passwordCnsr;
-	}
-	/**
-	 * passwordCnsr attribute 값을 설정한다.
-	 * @param passwordCnsr String
-	 */
-	public void setPasswordCnsr(String passwordCnsr) {
-		this.passwordCnsr = passwordCnsr;
-	}
-	/**
-	 * userSe attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUserSe() {
-		return userSe;
-	}
-	/**
-	 * userSe attribute 값을 설정한다.
-	 * @param userSe String
-	 */
-	public void setUserSe(String userSe) {
-		this.userSe = userSe;
-	}
-	/**
-	 * orgnztId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getOrgnztId() {
-		return orgnztId;
-	}
-	/**
-	 * orgnztId attribute 값을 설정한다.
-	 * @param orgnztId String
-	 */
-	public void setOrgnztId(String orgnztId) {
-		this.orgnztId = orgnztId;
-	}
-	/**
-	 * uniqId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUniqId() {
-		return uniqId;
-	}
-	/**
-	 * uniqId attribute 값을 설정한다.
-	 * @param uniqId String
-	 */
-	public void setUniqId(String uniqId) {
-		this.uniqId = uniqId;
-	}
-	/**
-	 * url attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUrl() {
-		return url;
-	}
-	/**
-	 * url attribute 값을 설정한다.
-	 * @param url String
-	 */
-	public void setUrl(String url) {
-		this.url = url;
-	}
-	/**
-	 * ip attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getIp() {
-		return ip;
-	}
-	/**
-	 * ip attribute 값을 설정한다.
-	 * @param ip String
-	 */
-	public void setIp(String ip) {
-		this.ip = ip;
-	}
-	/**
-	 * dn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getDn() {
-		return dn;
-	}
-	/**
-	 * dn attribute 값을 설정한다.
-	 * @param dn String
-	 */
-	public void setDn(String dn) {
-		this.dn = dn;
-	}
-	/**
-	 * @return the orgnztNm
-	 */
-	public String getOrgnztNm() {
-		return orgnztNm;
-	}
-	/**
-	 * @param orgnztNm the orgnztNm to set
-	 */
-	public void setOrgnztNm(String orgnztNm) {
-		this.orgnztNm = orgnztNm;
-	}
-	
+
 }


### PR DESCRIPTION
## 변경 사유

`LoginVO`, `ComDefaultVO`, `ComDefaultCodeVO` 세 클래스에 단순 필드 접근만 수행하는 수작업 getter/setter가 다수 존재했다. Lombok `@Getter`/`@Setter`를 적용해 보일러플레이트를 제거하고 코드 가독성을 높인다.

## 변경 내용

| 클래스 | 제거된 접근자 수 | 비고 |
|--------|----------------|------|
| `LoginVO` | 26개 (getter 13 + setter 13) | |
| `ComDefaultVO` | 18개 (getter 9 + setter 9) | `toString()` 보존 |
| `ComDefaultCodeVO` | 14개 (getter 7 + setter 7) | `toString()` 보존 |

- `serialVersionUID` 보존
- 기존 `toString()` 구현체(ToStringBuilder 기반) 보존 — Lombok `@ToString`으로 대체하지 않음
- pom.xml에 Lombok 의존성(`scope: provided`)이 이미 존재하므로 별도 의존성 추가 없음

## 영향 범위

Lombok이 생성하는 메서드명은 수작업 getter/setter와 동일하다. JSP EL(`${loginVO.id}`), MyBatis 매퍼 파라미터, Controller 호출부 모두 변경 불필요.

## 체크리스트

- [x] 단일 주제만 다룸 (VO 보일러플레이트 정리 외 변경 없음)
- [x] 5.0.x 브랜치 기준
- [x] 외부 메서드 시그니처 미변경
- [x] serialVersionUID 및 validation 어노테이션 보존
- [x] 기존 동작에 영향 없음