### PR TITLE
[test] Selenium 테스트 정비 또는 단위 테스트 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,12 @@
 			<artifactId>spring-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
+			<version>6.0.0</version>
+			<scope>test</scope>
+		</dependency>
 
 		<!-- CVE-2023-7272/CVE-2023-4043: 취약점 보완용 업데이트 -->
 		<dependency>
@@ -258,6 +264,13 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.42</version>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -277,7 +290,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<skipTests>true</skipTests>
+					<skipTests>false</skipTests>
 					<reportFormat>xml</reportFormat>
 					<excludes>
 						<exclude>**/Abstract*.java</exclude>

--- a/src/test/java/egovframework/let/uat/uia/web/EgovLoginControllerTestSelenium.java
+++ b/src/test/java/egovframework/let/uat/uia/web/EgovLoginControllerTestSelenium.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
@@ -14,6 +16,8 @@ import org.openqa.selenium.chrome.ChromeDriver;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@Disabled("Selenium tests require a running web server and a local Chrome browser.")
+@Tag("selenium")
 class EgovLoginControllerTestSelenium {
 
 	WebDriver driver;

--- a/src/test/java/egovframework/let/utl/fcc/service/EgovNumberUtilTest.java
+++ b/src/test/java/egovframework/let/utl/fcc/service/EgovNumberUtilTest.java
@@ -1,0 +1,53 @@
+package egovframework.let.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class EgovNumberUtilTest {
+
+	@Test
+	void testGetRandomNum() {
+		int start = 10;
+		int end = 20;
+		for (int i = 0; i < 50; i++) {
+			int rand = EgovNumberUtil.getRandomNum(start, end);
+			assertTrue(rand >= start && rand <= end);
+		}
+	}
+
+	@Test
+	void testGetNumSearchCheck() {
+		assertTrue(EgovNumberUtil.getNumSearchCheck(12345678, 7));
+		assertFalse(EgovNumberUtil.getNumSearchCheck(12345678, 9));
+	}
+
+	@Test
+	void testGetNumToStrCnvr() {
+		assertEquals("20081212", EgovNumberUtil.getNumToStrCnvr(20081212));
+		assertEquals("0", EgovNumberUtil.getNumToStrCnvr(0));
+	}
+
+	@Test
+	void testGetNumToDateCnvr() {
+		assertEquals("2008-12-12", EgovNumberUtil.getNumToDateCnvr(20081212));
+		assertThrows(IllegalArgumentException.class, () -> {
+			EgovNumberUtil.getNumToDateCnvr(123456);
+		});
+	}
+
+	@Test
+	void testGetNumberValidCheck() {
+		assertTrue(EgovNumberUtil.getNumberValidCheck("12345"));
+		assertFalse(EgovNumberUtil.getNumberValidCheck("12a45"));
+	}
+
+	@Test
+	void testGetNumberCnvr() {
+		assertEquals(99945678, EgovNumberUtil.getNumberCnvr(12345678, 123, 999));
+	}
+
+}

--- a/src/test/java/egovframework/let/utl/fcc/service/EgovStringUtilTest.java
+++ b/src/test/java/egovframework/let/utl/fcc/service/EgovStringUtilTest.java
@@ -1,0 +1,53 @@
+package egovframework.let.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class EgovStringUtilTest {
+
+	@Test
+	void testIsEmpty() {
+		assertTrue(EgovStringUtil.isEmpty(null));
+		assertTrue(EgovStringUtil.isEmpty(""));
+		assertFalse(EgovStringUtil.isEmpty(" "));
+		assertFalse(EgovStringUtil.isEmpty("abc"));
+	}
+
+	@Test
+	void testRemove() {
+		assertNull(EgovStringUtil.remove(null, 'a'));
+		assertEquals("", EgovStringUtil.remove("", 'a'));
+		assertEquals("qeed", EgovStringUtil.remove("queued", 'u'));
+		assertEquals("queued", EgovStringUtil.remove("queued", 'z'));
+	}
+
+	@Test
+	void testRemoveCommaChar() {
+		assertNull(EgovStringUtil.removeCommaChar(null));
+		assertEquals("", EgovStringUtil.removeCommaChar(""));
+		assertEquals("asdfgqweqe", EgovStringUtil.removeCommaChar("asdfg,qweqe"));
+	}
+
+	@Test
+	void testRemoveMinusChar() {
+		assertNull(EgovStringUtil.removeMinusChar(null));
+		assertEquals("", EgovStringUtil.removeMinusChar(""));
+		assertEquals("asdfgqweqe", EgovStringUtil.removeMinusChar("a-sdfg-qweqe"));
+	}
+
+	@Test
+	void testCutString() {
+		assertNull(EgovStringUtil.cutString(null, 5));
+		assertEquals("abc", EgovStringUtil.cutString("abc", 5));
+		assertEquals("ab", EgovStringUtil.cutString("abcde", 2));
+
+		assertNull(EgovStringUtil.cutString(null, "...", 5));
+		assertEquals("abc", EgovStringUtil.cutString("abc", "...", 5));
+		assertEquals("ab...", EgovStringUtil.cutString("abcde", "...", 2));
+	}
+
+}

--- a/src/test/resources/egovframework/spring/com/test-context-common.xml
+++ b/src/test/resources/egovframework/spring/com/test-context-common.xml
@@ -58,11 +58,11 @@
 	<bean id="defaultTraceHandler" class="egovframework.com.cmm.EgovComTraceHandler" />
 	
 	<!-- For Pagination Tag 설정-->
-	<bean id="krdsRenderer" class="egovframework.com.cmm.EgovKrdsPaginationRenderer"/>
+	<bean id="renewRenderer" class="egovframework.com.cmm.RenewPaginationRenderer"/>
 	<bean id="paginationManager" class="org.egovframe.rte.ptl.mvc.tags.ui.pagination.DefaultPaginationManager">
 		<property name="rendererType">
 			<map>
-				<entry key="krds" value-ref="krdsRenderer"/> 
+				<entry key="renew" value-ref="renewRenderer"/> 
 			</map>
 		</property>
 	</bean>


### PR DESCRIPTION
Selenium 테스트 EgovLoginControllerTestSelenium 파일에 @Disabled 및 @Tag("selenium") 어노테이션을 추가하여 불필요한 테스트 자원 낭비를 방지하고 빌드 안정성을 확보했습니다. 또한, 테스트 빌드 과정에서 Lombok 어노테이션 프로세싱 오류 및 Spring Test 6.2+와 jakarta.servlet-api 간의 NoClassDefFoundError 오류를 해결하기 위해 pom.xml 설정을 보완하였으며, 테스트 컨텍스트 설정에 참조된 유효하지 않은 egovframework.com.cmm.EgovKrdsPaginationRenderer를 실제 사용 중인 RenewPaginationRenderer로 대체하였습니다. 마지막으로, EgovStringUtil 및 EgovNumberUtil 클래스에 대한 유틸리티 단위 테스트를 추가하여 기능 검증을 보강했습니다.