### PR TITLE
[refactor][simple-homepage] uat/uia 로그인 XML 매퍼 @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/let/uat/uia/service/impl/EgovLoginServiceImpl.java
+++ b/src/main/java/egovframework/let/uat/uia/service/impl/EgovLoginServiceImpl.java
@@ -31,7 +31,7 @@ import jakarta.annotation.Resource;
 public class EgovLoginServiceImpl extends EgovAbstractServiceImpl implements EgovLoginService {
 
 	@Resource(name = "loginDAO")
-	private LoginDAO loginDAO;
+	private LoginMapper loginDAO;
 
 	/**
 	 * 일반 로그인을 처리한다

--- a/src/main/java/egovframework/let/uat/uia/service/impl/LoginMapper.java
+++ b/src/main/java/egovframework/let/uat/uia/service/impl/LoginMapper.java
@@ -1,0 +1,57 @@
+package egovframework.let.uat.uia.service.impl;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.LoginVO;
+
+/**
+ * 일반 로그인을 처리하는 MyBatis 매퍼 인터페이스
+ * @author 공통서비스 개발팀 박지욱
+ * @since 2009.03.06
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자          수정내용
+ *  -------    --------    ---------------------------
+ *  2009.03.06  박지욱          최초 생성
+ *  2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper("loginDAO")
+public interface LoginMapper {
+
+	/**
+	 * 일반 로그인을 처리한다
+	 * @param vo LoginVO
+	 * @return LoginVO
+	 * @exception Exception
+	 */
+	LoginVO actionLogin(LoginVO vo) throws Exception;
+
+	/**
+	 * 아이디를 찾는다.
+	 * @param vo LoginVO
+	 * @return LoginVO
+	 * @exception Exception
+	 */
+	LoginVO searchId(LoginVO vo) throws Exception;
+
+	/**
+	 * 비밀번호를 찾는다.
+	 * @param vo LoginVO
+	 * @return LoginVO
+	 * @exception Exception
+	 */
+	LoginVO searchPassword(LoginVO vo) throws Exception;
+
+	/**
+	 * 변경된 비밀번호를 저장한다.
+	 * @param vo LoginVO
+	 * @exception Exception
+	 */
+	void updatePassword(LoginVO vo) throws Exception;
+}

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_hsql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,5 +22,11 @@
 	</bean>
 	
 	<alias name="sqlSession" alias="egov.sqlSession" />
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 매퍼 인터페이스 자동 등록 -->
+	<bean class="org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer">
+		<property name="basePackage" value="egovframework.let.uat.uia.service.impl" />
+		<property name="sqlSessionFactoryBeanName" value="sqlSession" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 개요

`uat/uia` 모듈의 로그인 데이터 접근 계층을 기존 `EgovAbstractMapper` 상속 방식(DAO 클래스)에서 eGovFrame 5.0에서 도입된 `@EgovMapper` 인터페이스 방식으로 전환한다.

## 변경 내용

- `LoginMapper` 인터페이스 신규 추가 (`@EgovMapper("loginDAO")`)
- `EgovLoginServiceImpl`: `LoginDAO` 클래스 주입 → `LoginMapper` 인터페이스 주입으로 변경
- `EgovLoginUsr_SQL_*.xml` (6개 DB 방언): `namespace="loginDAO"` → `namespace="egovframework.let.uat.uia.service.impl.LoginMapper"` 변경
- `context-mapper.xml`: `MapperConfigurer` 빈 추가 (`basePackage` = `egovframework.let.uat.uia.service.impl`)

## 영향 범위

로그인 기능(`/uat/uia`) 데이터 접근 계층 한정. SQL 내용 변경 없음. 런타임 동작 동일.

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 의존성 추가 없음 (`egovframe-rte-psl-dataaccess`에 `@EgovMapper` 포함)
- [x] 기존 동작에 영향 없음 (SQL 변경 없음, 빈 이름 `loginDAO` 유지)
- [x] `mvn compile` 통과 확인
