### PR TITLE
[refactor][simple-homepage] cop/smt/sim IndvdlSchdulManageDAO @EgovMapper 인터페이스 매핑

### DIFF
--- a/src/main/java/egovframework/let/cop/smt/sim/service/impl/EgovIndvdlSchdulManageServiceImpl.java
+++ b/src/main/java/egovframework/let/cop/smt/sim/service/impl/EgovIndvdlSchdulManageServiceImpl.java
@@ -29,7 +29,7 @@ import jakarta.annotation.Resource;
 public class EgovIndvdlSchdulManageServiceImpl extends EgovAbstractServiceImpl implements EgovIndvdlSchdulManageService{
 
 	@Resource(name="indvdlSchdulManageDao")
-	private IndvdlSchdulManageDao dao;
+	private IndvdlSchdulManageMapper dao;
 
 
 	@Resource(name="deptSchdulManageIdGnrService")
@@ -77,7 +77,7 @@ public class EgovIndvdlSchdulManageServiceImpl extends EgovAbstractServiceImpl i
 	 */
 	@Override
 	public List<?> selectIndvdlSchdulManageList(ComDefaultVO searchVO) throws Exception{
-		return dao.selectIndvdlSchdulManageList(searchVO);
+		return dao.selectIndvdlSchdulManage(searchVO);
 	}
 
     /**
@@ -99,7 +99,7 @@ public class EgovIndvdlSchdulManageServiceImpl extends EgovAbstractServiceImpl i
 	 */
 	@Override
 	public int selectIndvdlSchdulManageListCnt(ComDefaultVO searchVO) throws Exception{
-		return dao.selectIndvdlSchdulManageListCnt(searchVO);
+		return dao.selectIndvdlSchdulManageCnt(searchVO);
 	}
 
     /**

--- a/src/main/java/egovframework/let/cop/smt/sim/service/impl/IndvdlSchdulManageMapper.java
+++ b/src/main/java/egovframework/let/cop/smt/sim/service/impl/IndvdlSchdulManageMapper.java
@@ -1,0 +1,99 @@
+package egovframework.let.cop.smt.sim.service.impl;
+
+import java.util.List;
+import java.util.Map;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO;
+
+/**
+ * 개인일정 관리를 처리하는 MyBatis 매퍼 인터페이스
+ * @author 조재영
+ * @since 2009.04.10
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *  2009.04.10  장동한          최초 생성
+ *  2011.05.31  JJY            경량환경 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper("indvdlSchdulManageDao")
+public interface IndvdlSchdulManageMapper {
+
+	/**
+	 * 메인페이지/일정관리조회 목록을 조회한다.
+	 * @param map 조회할 정보가 담긴 Map
+	 * @return List
+	 * @throws Exception
+	 */
+	List<?> selectIndvdlSchdulManageMainList(Map<?, ?> map) throws Exception;
+
+	/**
+	 * 일정 목록을 Map 형식으로 조회한다.
+	 * @param map 조회할 정보가 담긴 Map
+	 * @return List
+	 * @throws Exception
+	 */
+	List<?> selectIndvdlSchdulManageRetrieve(Map<?, ?> map) throws Exception;
+
+	/**
+	 * 일정 목록을 VO 형식으로 조회한다.
+	 * @param indvdlSchdulManageVO 조회할 정보가 담긴 VO
+	 * @return IndvdlSchdulManageVO
+	 * @throws Exception
+	 */
+	IndvdlSchdulManageVO selectIndvdlSchdulManageDetailVO(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception;
+
+	/**
+	 * 일정 목록을 조회한다. (XML id: selectIndvdlSchdulManage)
+	 * @param searchVO 조회할 정보가 담긴 VO
+	 * @return List
+	 * @throws Exception
+	 */
+	List<?> selectIndvdlSchdulManage(ComDefaultVO searchVO) throws Exception;
+
+	/**
+	 * 일정 상세정보를 조회한다.
+	 * @param indvdlSchdulManageVO 일정 정보 담긴 VO
+	 * @return List
+	 * @throws Exception
+	 */
+	List<?> selectIndvdlSchdulManageDetail(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception;
+
+	/**
+	 * 일정 목록 전체 건수를 조회한다. (XML id: selectIndvdlSchdulManageCnt)
+	 * @param searchVO 조회할 정보가 담긴 VO
+	 * @return int
+	 * @throws Exception
+	 */
+	int selectIndvdlSchdulManageCnt(ComDefaultVO searchVO) throws Exception;
+
+	/**
+	 * 일정을 등록한다.
+	 * @param indvdlSchdulManageVO 일정 정보 담긴 VO
+	 * @throws Exception
+	 */
+	void insertIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception;
+
+	/**
+	 * 일정을 수정한다.
+	 * @param indvdlSchdulManageVO 일정 정보 담긴 VO
+	 * @throws Exception
+	 */
+	void updateIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception;
+
+	/**
+	 * 일정을 삭제한다.
+	 * @param indvdlSchdulManageVO 일정 정보 담긴 VO
+	 * @throws Exception
+	 */
+	void deleteIndvdlSchdulManage(IndvdlSchdulManageVO indvdlSchdulManageVO) throws Exception;
+}

--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.let.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO">

--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.let.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO">

--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_hsql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.let.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO">

--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.let.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO">

--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.let.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO">

--- a/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/smt/sim/EgovIndvdlSchdulManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="IndvdlSchdulManage">
+<mapper namespace="egovframework.let.cop.smt.sim.service.impl.IndvdlSchdulManageMapper">
 
 
 	<resultMap id="IndvdlSchdulManage" type="egovframework.let.cop.smt.sim.service.IndvdlSchdulManageVO">


### PR DESCRIPTION
## 변경 사유
simple-homepage의 `cop/smt/sim` (개인일정관리) DAO를 `@EgovMapper` 인터페이스 방식으로 전환. PR #40(uat/uia LoginDAO) 동일 패턴.

## 변경 내용
- 신규 `IndvdlSchdulManageMapper` 인터페이스(@EgovMapper) 추가
- `EgovIndvdlSchdulManageServiceImpl`: 매퍼 인터페이스 의존성으로 변경
- 6개 RDBMS XML namespace를 인터페이스 FQN으로 변경
- SQL 무변경

## 영향 범위
- 외부 동작 변경 없음
- mvn compile BUILD SUCCESS

## 체크리스트
- [x] 단일 모듈
- [x] PR #40과 다른 모듈
