### PR TITLE
[refactor][5.0.x][simple-homepage] sym/cal RestdeManageDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/let/sym/cal/service/impl/EgovCalRestdeManageServiceImpl.java
+++ b/src/main/java/egovframework/let/sym/cal/service/impl/EgovCalRestdeManageServiceImpl.java
@@ -31,8 +31,8 @@ import jakarta.annotation.Resource;
 @Service("RestdeManageService")
 public class EgovCalRestdeManageServiceImpl extends EgovAbstractServiceImpl implements EgovCalRestdeManageService {
 
-    @Resource(name="RestdeManageDAO")
-    private RestdeManageDAO restdeManageDAO;
+    @Resource(name="restdeManageDao")
+    private RestdeManageMapper restdeManageDAO;
 
 	/**
 	 * 일반달력 팝업 정보를 조회한다.

--- a/src/main/java/egovframework/let/sym/cal/service/impl/RestdeManageMapper.java
+++ b/src/main/java/egovframework/let/sym/cal/service/impl/RestdeManageMapper.java
@@ -1,0 +1,139 @@
+package egovframework.let.sym.cal.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.sym.cal.service.Restde;
+import egovframework.let.sym.cal.service.RestdeVO;
+
+/**
+ * 휴일 관리를 처리하는 MyBatis 매퍼 인터페이스
+ * @author 공통서비스 개발팀 이중호
+ * @since 2009.04.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.01  이중호          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper("restdeManageDao")
+public interface RestdeManageMapper {
+
+	/**
+	 * 일반달력 팝업 정보를 조회한다.
+	 * @param restde
+	 * @return List(일반달력 팝업 날짜정보)
+	 * @throws Exception
+	 */
+	List<?> selectNormalRestdePopup(Restde restde) throws Exception;
+
+	/**
+	 * 행정달력 팝업 정보를 조회한다.
+	 * @param restde
+	 * @return List(행정달력 팝업 날짜정보)
+	 * @throws Exception
+	 */
+	List<?> selectAdministRestdePopup(Restde restde) throws Exception;
+
+	/**
+	 * 일반달력 일간 정보를 조회한다.
+	 * @param restde
+	 * @return List(일반달력 일간 날짜정보)
+	 * @throws Exception
+	 */
+	List<?> selectNormalDayCal(Restde restde) throws Exception;
+
+	/**
+	 * 일반달력 일간 휴일을 조회한다.
+	 * @param restde
+	 * @return List(일반달력 일간 휴일정보)
+	 * @throws Exception
+	 */
+	List<?> selectNormalDayRestde(Restde restde) throws Exception;
+
+	/**
+	 * 일반달력 월간 휴일을 조회한다.
+	 * @param restde
+	 * @return List(일반달력 월간 휴일정보)
+	 * @throws Exception
+	 */
+	List<?> selectNormalMonthRestde(Restde restde) throws Exception;
+
+	/**
+	 * 행정달력 일간 정보를 조회한다.
+	 * @param restde
+	 * @return List(행정달력 일간 날짜정보)
+	 * @throws Exception
+	 */
+	List<?> selectAdministDayCal(Restde restde) throws Exception;
+
+	/**
+	 * 행정달력 일간 휴일을 조회한다.
+	 * @param restde
+	 * @return List(행정달력 일간 휴일정보)
+	 * @throws Exception
+	 */
+	List<?> selectAdministDayRestde(Restde restde) throws Exception;
+
+	/**
+	 * 행정달력 월간 휴일을 조회한다.
+	 * @param restde
+	 * @return List(행정달력 월간 휴일정보)
+	 * @throws Exception
+	 */
+	List<?> selectAdministMonthRestde(Restde restde) throws Exception;
+
+	/**
+	 * 휴일을 삭제한다.
+	 * @param restde
+	 * @throws Exception
+	 */
+	void deleteRestde(Restde restde) throws Exception;
+
+	/**
+	 * 휴일을 등록한다.
+	 * @param restde
+	 * @throws Exception
+	 */
+	void insertRestde(Restde restde) throws Exception;
+
+	/**
+	 * 휴일 상세항목을 조회한다.
+	 * @param restde
+	 * @return Restde(휴일)
+	 * @throws Exception
+	 */
+	Restde selectRestdeDetail(Restde restde) throws Exception;
+
+	/**
+	 * 휴일 목록을 조회한다.
+	 * @param searchVO
+	 * @return List(휴일 목록)
+	 * @throws Exception
+	 */
+	List<?> selectRestdeList(RestdeVO searchVO) throws Exception;
+
+	/**
+	 * 휴일 총 갯수를 조회한다.
+	 * @param searchVO
+	 * @return int(휴일 총 갯수)
+	 * @throws Exception
+	 */
+	int selectRestdeListTotCnt(RestdeVO searchVO) throws Exception;
+
+	/**
+	 * 휴일을 수정한다.
+	 * @param restde
+	 * @throws Exception
+	 */
+	void updateRestde(Restde restde) throws Exception;
+
+}

--- a/src/main/resources/egovframework/mapper/let/sym/cal/EgovRestdeManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/cal/EgovRestdeManage_SQL_altibase.xml
@@ -1,0 +1,324 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
+"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="restdeManageDao">
+
+	<select id="selectNormalRestdePopup" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  CAST(#{year} AS NUMERIC)               YEAR
+                 ,  CAST(#{month} AS NUMERIC)              MONTH
+                 ,  DECODE(GREATEST(T_DUMMY.RNUM + 1 - CAST(#{startWeekMonth} AS NUMERIC),0),0,'',DECODE(GREATEST(T_DUMMY.RNUM + 1 - CAST(#{startWeekMonth} AS NUMERIC),CAST(#{lastDayMonth} AS NUMERIC)),CAST(#{lastDayMonth} AS NUMERIC),TO_CHAR(T_DUMMY.RNUM + 1 - CAST(#{startWeekMonth} AS NUMERIC)),''))
+                                         DAY 
+                 ,  T_DUMMY.RNUM           CELL_NUM
+                 ,  T_DUMMY.WEEKS + 1      WEEKS
+                 ,  T_DUMMY.WEEK           WEEK
+                 ,  (
+                    SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE T_DUMMY.WEEK WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+                      FROM  COMTNRESTDE 
+                     WHERE  RESTDE = LPAD(#{year},4,'0')
+                                      ||LPAD(#{month},2,'0')
+                                      ||LPAD(DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},0),0,'',DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},#{lastDayMonth}),#{lastDayMonth},TO_CHAR(T_DUMMY.RNUM + 1 - #{startWeekMonth}),''))
+                    			             ,2,'0'
+                    			            )
+                       AND  RESTDE_SE_CODE IN ('01','02')                                   
+                    ) REST_AT
+              FROM  (
+                    SELECT  (W.W*7) + D.D RNUM
+                         ,  W.W WEEKS
+                         ,  D.D WEEK
+                      FROM  (
+						    SELECT 0 W  FROM DUAL
+						    UNION ALL
+						    SELECT 1 FROM DUAL
+						    UNION ALL
+						    SELECT 2 FROM DUAL
+						    UNION ALL
+						    SELECT 3 FROM DUAL
+						    UNION ALL
+						    SELECT 4 FROM DUAL
+						    UNION ALL
+						    SELECT 5 FROM DUAL
+						    ) W,
+						    (
+						    SELECT 1 D FROM DUAL
+						    UNION ALL
+						    SELECT 2 FROM DUAL
+						    UNION ALL
+						    SELECT 3 FROM DUAL
+						    UNION ALL
+						    SELECT 4 FROM DUAL
+						    UNION ALL
+						    SELECT 5 FROM DUAL
+						    UNION ALL
+						    SELECT 6 FROM DUAL
+						    UNION ALL
+						    SELECT 7 FROM DUAL
+                            ) D
+                    ORDER BY (W.W*7) + D.D
+            ) T_DUMMY
+			ORDER BY T_DUMMY.RNUM            
+		
+	</select>
+
+	<select id="selectAdministRestdePopup" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  '#{year}'               YEAR
+                 ,  '#{month}'              MONTH
+                 ,  DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},0),0,'',DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},#{lastDayMonth}),#{lastDayMonth},TO_CHAR(T_DUMMY.RNUM + 1 - #{startWeekMonth}),''))
+                                         DAY 
+                 ,  T_DUMMY.RNUM           CELL_NUM
+                 ,  T_DUMMY.WEEKS + 1      WEEKS
+                 ,  T_DUMMY.WEEK           WEEK
+                 ,  (
+                    SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE T_DUMMY.WEEK WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+                      FROM  COMTNRESTDE 
+                     WHERE  RESTDE = LPAD('#{year}',4,'0')
+                                      ||LPAD('#{month}',2,'0')
+                                      ||LPAD(DECODE(GREATEST(T_DUMMY.RNUM + 1 - '#{startWeekMonth}',0),0,'',DECODE(GREATEST(T_DUMMY.RNUM + 1 - '#{startWeekMonth}','#{lastDayMonth}'),'#{lastDayMonth}',TO_CHAR(T_DUMMY.RNUM + 1 - '#{startWeekMonth}'),''))
+                    			             ,2,'0'
+                    			            )
+                       AND  RESTDE_SE_CODE IN ('02','03')                                   
+                    ) REST_AT
+              FROM  (
+                    SELECT  (W.W*7) + D.D RNUM
+                         ,  W.W WEEKS
+                         ,  D.D WEEK
+                      FROM  (
+						    SELECT 0 W  FROM DUAL
+						    UNION ALL
+						    SELECT 1 FROM DUAL
+						    UNION ALL
+						    SELECT 2 FROM DUAL
+						    UNION ALL
+						    SELECT 3 FROM DUAL
+						    UNION ALL
+						    SELECT 4 FROM DUAL
+						    UNION ALL
+						    SELECT 5 FROM DUAL
+						    ) W,
+						    (
+						    SELECT 1 D FROM DUAL
+						    UNION ALL
+						    SELECT 2 FROM DUAL
+						    UNION ALL
+						    SELECT 3 FROM DUAL
+						    UNION ALL
+						    SELECT 4 FROM DUAL
+						    UNION ALL
+						    SELECT 5 FROM DUAL
+						    UNION ALL
+						    SELECT 6 FROM DUAL
+						    UNION ALL
+						    SELECT 7 FROM DUAL
+                            ) D
+                    ORDER BY (W.W*7) + D.D
+            ) T_DUMMY
+			ORDER BY T_DUMMY.RNUM            
+		
+	</select>
+
+	<select id="selectNormalDayCal" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+			SELECT  '#{year}'               YEAR
+			     ,  '#{month}'              MONTH
+				 ,  '#{day}'                DAY
+				 ,  #{week}                 WEEK
+				 ,  #{weeks}                WEEKS
+				 ,  #{maxWeeks}             MAX_WEEKS
+				 ,  #{lastDayMonth}         LAST_DAY_MONTH
+			     ,  (	SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE #{week} WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+			              FROM  COMTNRESTDE 
+			             WHERE  RESTDE = LPAD('#{year}',4,'0')||LPAD('#{month}',2,'0')||LPAD('#{day}',2,'0')
+			               AND  RESTDE_SE_CODE IN ('01','02')                                   
+			        ) REST_AT
+			  FROM  DUAL      
+		
+	</select>
+	
+	<select id="selectNormalDayRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  '#{year}'     YEAR
+                 ,  '#{month}'    MONTH
+                 ,  '#{day}'      DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE 
+             WHERE  RESTDE         = LPAD('#{year}',4,'0')||LPAD('#{month}',2,'0')||LPAD('#{day}',2,'0')
+               AND  RESTDE_SE_CODE   IN ('01','02')       
+		
+	</select>
+
+	<select id="selectNormalMonthRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  '#{year}'                YEAR
+                 ,  '#{month}'               MONTH
+                 ,  TO_CHAR(TO_NUMBER( SUBSTR(RESTDE,7,2))) DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE 
+             WHERE  RESTDE      LIKE LPAD('#{year}',4,'0')||LPAD('#{month}',2,'0')||'%'
+               AND  RESTDE_SE_CODE   IN ('01','02')       
+		
+	</select>
+
+	<select id="selectAdministDayCal" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+			SELECT  '#{year}'               YEAR
+			     ,  '#{month}'              MONTH
+				 ,  '#{day}'                DAY
+				 ,  #{week}                 WEEK
+				 ,  #{weeks}                WEEKS
+				 ,  #{maxWeeks}             MAX_WEEKS
+				 ,  #{lastDayMonth}         LAST_DAY_MONTH
+			     ,  (	SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE #{week} WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+			              FROM  COMTNRESTDE 
+			             WHERE  RESTDE = LPAD('#{year}',4,'0')||LPAD('#{month}',2,'0')||LPAD('#{day}',2,'0')
+			               AND  RESTDE_SE_CODE IN ('02','03')                                   
+			        ) REST_AT
+			  FROM  DUAL      
+		
+	</select>
+	
+	<select id="selectAdministDayRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  '#{year}'     YEAR
+                 ,  '#{month}'    MONTH
+                 ,  '#{day}'      DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE 
+             WHERE  RESTDE         = LPAD('#{year}',4,'0')||LPAD('#{month}',2,'0')||LPAD('#{day}',2,'0')
+               AND  RESTDE_SE_CODE   IN ('02','03')       
+		
+	</select>
+
+	<select id="selectAdministMonthRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  '#{year}'                YEAR
+                 ,  '#{month}'               MONTH
+                 ,  TO_CHAR(TO_NUMBER(SUBSTR(RESTDE,7,2))) DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE 
+             WHERE  RESTDE      LIKE LPAD('#{year}',4,'0')||LPAD('#{month}',2,'0')||'%'
+               AND  RESTDE_SE_CODE   IN ('02','03')       
+		
+	</select>
+
+	<!-- 2024.10.29 권태성 휴일일자 검색 조건인 경우 searchKeyword를 formattedDtKeyword로 변경 -->
+	<select id="selectRestdeList" parameterType="egovframework.let.sym.cal.service.RestdeVO" resultType="egovMap">
+		
+			SELECT  * 
+			  FROM  (
+			SELECT ROWNUM RNUM, ALL_LIST.* 
+			  FROM  (
+			/* 구현 Sql */
+			SELECT  A.RESTDE_NO
+				 ,  A.RESTDE RESTDE_DE
+			     ,  A.RESTDE DBMS_KIND 
+				 ,  A.RESTDE_NM
+				 ,  A.RESTDE_DC
+				 ,  B.CODE_NM        RESTDE_SE
+				 ,  A.RESTDE_SE_CODE
+			  FROM  COMTNRESTDE         A
+			     ,  COMTCCMMNDETAILCODE B
+			 WHERE  B.CODE_ID        = 'COM017'
+			   AND  A.RESTDE_SE_CODE = B.CODE
+		
+			<if test="searchCondition == 1">AND
+				A.RESTDE = #{formattedDtKeyword}
+			</if>
+			<if test="searchCondition == 2">AND
+				A.RESTDE_NM LIKE '%' || #{searchKeyword} || '%'
+			</if>
+		<![CDATA[
+			/* 구현 Sql */
+				    ) ALL_LIST
+				    )
+			 WHERE  RNUM  > #{firstIndex}
+			   AND  RNUM <= #{firstIndex} + #{recordCountPerPage}
+		]]>
+	</select>
+
+	<!-- 2024.10.29 권태성 휴일일자 검색 조건인 경우 searchKeyword를 formattedDtKeyword로 변경 -->
+	<select id="selectRestdeListTotCnt" parameterType="egovframework.let.sym.cal.service.RestdeVO" resultType="int">
+		
+			SELECT  COUNT(*) totcnt 
+			  FROM  COMTNRESTDE         A
+			     ,  COMTCCMMNDETAILCODE B
+			 WHERE  B.CODE_ID        = 'COM017'
+			   AND  A.RESTDE_SE_CODE = B.CODE
+		
+			<if test="searchCondition == 1">AND
+				RESTDE = #{formattedDtKeyword}
+			</if>
+			<if test="searchCondition == 2">AND
+				RESTDE_NM LIKE '%' || #{searchKeyword} || '%'
+			</if>
+	</select>
+
+	<insert id="insertRestde">
+		
+			INSERT 
+			  INTO  COMTNRESTDE
+			     (  RESTDE_NO
+				 ,  RESTDE
+				 ,  RESTDE_NM
+				 ,  RESTDE_DC
+				 ,  RESTDE_SE_CODE
+			     ,  FRST_REGIST_PNTTM
+			     ,  FRST_REGISTER_ID
+			     ,  LAST_UPDT_PNTTM
+			     ,  LAST_UPDUSR_ID
+			     ) 
+			VALUES
+			     (  #{restdeNo}
+				 ,  #{restdeDe}
+				 ,  #{restdeNm}
+				 ,  #{restdeDc}
+				 ,  #{restdeSeCode}
+			     ,  SYSDATE
+			     ,  #{frstRegisterId}
+			     ,  SYSDATE
+			     ,  #{frstRegisterId}
+			     ) 
+		
+	</insert>
+
+	<select id="selectRestdeDetail" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovframework.let.sym.cal.service.Restde">
+		
+			SELECT  A.RESTDE_NO      restdeNo
+			     ,  A.RESTDE      restdeDe
+				 ,  A.RESTDE_NM      restdeNm
+				 ,  A.RESTDE_DC      restdeDc
+				 ,  B.CODE_NM        restdeSe
+				 ,  A.RESTDE_SE_CODE restdeSeCode
+			  FROM  COMTNRESTDE         A
+			     ,  COMTCCMMNDETAILCODE B
+			 WHERE  B.CODE_ID        = 'COM017'
+			   AND  A.RESTDE_SE_CODE = B.CODE
+               AND  A.RESTDE_NO      = #{restdeNo}
+		
+	</select>
+
+	<update id="updateRestde">
+		
+            UPDATE  COMTNRESTDE 
+               SET  RESTDE_NM         = #{restdeNm}
+				 ,  RESTDE_DC         = #{restdeDc}
+				 ,  RESTDE_SE_CODE    = #{restdeSeCode}
+                 ,  LAST_UPDT_PNTTM = sysdate
+                 ,  LAST_UPDUSR_ID    = #{lastUpdusrId}
+             WHERE  RESTDE_NO         = #{restdeNo}
+		
+	</update>
+
+	<delete id="deleteRestde">
+		
+            DELETE  
+              FROM  COMTNRESTDE     
+             WHERE  RESTDE_NO = #{restdeNo}
+		
+	</delete>
+	
+</mapper>

--- a/src/main/resources/egovframework/mapper/let/sym/cal/EgovRestdeManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/cal/EgovRestdeManage_SQL_cubrid.xml
@@ -1,0 +1,324 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
+"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="restdeManageDao">
+
+	<select id="selectNormalRestdePopup" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}               "YEAR"
+                 ,  #{month}              "MONTH"
+                 ,  DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},0),0,'',DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},#{lastDayMonth}),#{lastDayMonth},TO_CHAR(T_DUMMY.RNUM + 1 - #{startWeekMonth}),''))
+                                         "DAY"
+                 ,  T_DUMMY.RNUM           CELL_NUM
+                 ,  T_DUMMY.WEEKS + 1      WEEKS
+                 ,  T_DUMMY.WEEK           "WEEK"
+                 ,  (
+                    SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE T_DUMMY.WEEK WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+                      FROM  COMTNRESTDE
+                     WHERE  RESTDE = LPAD(#{year},4,'0')
+                                      ||LPAD(#{month},2,'0')
+                                      ||LPAD(DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},0),0,'',DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},#{lastDayMonth}),#{lastDayMonth},TO_CHAR(T_DUMMY.RNUM + 1 - #{startWeekMonth}),''))
+                    			             ,2,'0'
+                    			            )
+                       AND  RESTDE_SE_CODE IN ('01','02')
+                    ) REST_AT
+              FROM  (
+                    SELECT  (W.W*7) + D.D RNUM
+                         ,  W.W WEEKS
+                         ,  D.D WEEK
+                      FROM  (
+						    SELECT 0 W  FROM DB_ROOT
+						    UNION ALL
+						    SELECT 1 FROM DB_ROOT
+						    UNION ALL
+						    SELECT 2 FROM DB_ROOT
+						    UNION ALL
+						    SELECT 3 FROM DB_ROOT
+						    UNION ALL
+						    SELECT 4 FROM DB_ROOT
+						    UNION ALL
+						    SELECT 5 FROM DB_ROOT
+						    ) W,
+						    (
+						    SELECT 1 D FROM DB_ROOT
+						    UNION ALL
+						    SELECT 2 FROM DB_ROOT
+						    UNION ALL
+						    SELECT 3 FROM DB_ROOT
+						    UNION ALL
+						    SELECT 4 FROM DB_ROOT
+						    UNION ALL
+						    SELECT 5 FROM DB_ROOT
+						    UNION ALL
+						    SELECT 6 FROM DB_ROOT
+						    UNION ALL
+						    SELECT 7 FROM DB_ROOT
+                            ) D
+                    ORDER BY (W.W*7) + D.D
+            ) T_DUMMY
+			ORDER BY T_DUMMY.RNUM
+		
+	</select>
+
+	<select id="selectAdministRestdePopup" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}               "YEAR"
+                 ,  #{month}              "MONTH"
+                 ,  DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},0),0,'',DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},#{lastDayMonth}),#{lastDayMonth},TO_CHAR(T_DUMMY.RNUM + 1 - #{startWeekMonth}),''))
+                                         "DAY"
+                 ,  T_DUMMY.RNUM           CELL_NUM
+                 ,  T_DUMMY.WEEKS + 1      WEEKS
+                 ,  T_DUMMY.WEEK           "WEEK"
+                 ,  (
+                    SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE T_DUMMY.WEEK WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+                      FROM  COMTNRESTDE
+                     WHERE  RESTDE = LPAD(#{year},4,'0')
+                                      ||LPAD(#{month},2,'0')
+                                      ||LPAD(DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},0),0,'',DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},#{lastDayMonth}),#{lastDayMonth},TO_CHAR(T_DUMMY.RNUM + 1 - #{startWeekMonth}),''))
+                    			             ,2,'0'
+                    			            )
+                       AND  RESTDE_SE_CODE IN ('02','03')
+                    ) REST_AT
+              FROM  (
+                    SELECT  (W.W*7) + D.D RNUM
+                         ,  W.W WEEKS
+                         ,  D.D WEEK
+                      FROM  (
+						    SELECT 0 W  FROM DB_ROOT
+						    UNION ALL
+						    SELECT 1 FROM DB_ROOT
+						    UNION ALL
+						    SELECT 2 FROM DB_ROOT
+						    UNION ALL
+						    SELECT 3 FROM DB_ROOT
+						    UNION ALL
+						    SELECT 4 FROM DB_ROOT
+						    UNION ALL
+						    SELECT 5 FROM DB_ROOT
+						    ) W,
+						    (
+						    SELECT 1 D FROM DB_ROOT
+						    UNION ALL
+						    SELECT 2 FROM DB_ROOT
+						    UNION ALL
+						    SELECT 3 FROM DB_ROOT
+						    UNION ALL
+						    SELECT 4 FROM DB_ROOT
+						    UNION ALL
+						    SELECT 5 FROM DB_ROOT
+						    UNION ALL
+						    SELECT 6 FROM DB_ROOT
+						    UNION ALL
+						    SELECT 7 FROM DB_ROOT
+                            ) D
+                    ORDER BY (W.W*7) + D.D
+            ) T_DUMMY
+			ORDER BY T_DUMMY.RNUM
+		
+	</select>
+
+	<select id="selectNormalDayCal" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+			SELECT  #{year}               "YEAR"
+			     ,  #{month}              "MONTH"
+				 ,  #{day}                "DAY"
+				 ,  #{week}                 "WEEK"
+				 ,  #{weeks}                WEEKS
+				 ,  #{maxWeeks}             MAX_WEEKS
+				 ,  #{lastDayMonth}         LAST_DAY_MONTH
+			     ,  (	SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE #{week} WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+			              FROM  COMTNRESTDE
+			             WHERE  RESTDE = LPAD(#{year},4,'0')||LPAD(#{month},2,'0')||LPAD(#{day},2,'0')
+			               AND  RESTDE_SE_CODE IN ('01','02')
+			        ) REST_AT
+			  FROM  DB_ROOT
+		
+	</select>
+
+	<select id="selectNormalDayRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}     "YEAR"
+                 ,  #{month}    "MONTH"
+                 ,  #{day}      "DAY"
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE
+             WHERE  RESTDE         = LPAD(#{year},4,'0')||LPAD(#{month},2,'0')||LPAD(#{day},2,'0')
+               AND  RESTDE_SE_CODE   IN ('01','02')
+		
+	</select>
+
+	<select id="selectNormalMonthRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}                "YEAR"
+                 ,  #{month}               "MONTH"
+                 ,  TO_CHAR(TO_NUMBER( SUBSTR(RESTDE,7,2))) "DAY"
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE
+             WHERE  RESTDE      LIKE LPAD(#{year},4,'0')||LPAD(#{month},2,'0')||'%'
+               AND  RESTDE_SE_CODE   IN ('01','02')
+		
+	</select>
+
+	<select id="selectAdministDayCal" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+			SELECT  #{year}               "YEAR"
+			     ,  #{month}              "MONTH"
+				 ,  #{day}                "DAY"
+				 ,  #{week}                 "WEEK"
+				 ,  #{weeks}                WEEKS
+				 ,  #{maxWeeks}             MAX_WEEKS
+				 ,  #{lastDayMonth}         LAST_DAY_MONTH
+			     ,  (	SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE #{week} WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+			              FROM  COMTNRESTDE
+			             WHERE  RESTDE = LPAD(#{year},4,'0')||LPAD(#{month},2,'0')||LPAD(#{day},2,'0')
+			               AND  RESTDE_SE_CODE IN ('02','03')
+			        ) REST_AT
+			  FROM  DB_ROOT
+		
+	</select>
+
+	<select id="selectAdministDayRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}     "YEAR"
+                 ,  #{month}    "MONTH"
+                 ,  #{day}      "DAY"
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE
+             WHERE  RESTDE         = LPAD(#{year},4,'0')||LPAD(#{month},2,'0')||LPAD(#{day},2,'0')
+               AND  RESTDE_SE_CODE   IN ('02','03')
+		
+	</select>
+
+	<select id="selectAdministMonthRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}                "YEAR"
+                 ,  #{month}               "MONTH"
+                 ,  TO_CHAR(TO_NUMBER(SUBSTR(RESTDE,7,2))) "DAY"
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE
+             WHERE  RESTDE      LIKE LPAD(#{year},4,'0')||LPAD(#{month},2,'0')||'%'
+               AND  RESTDE_SE_CODE   IN ('02','03')
+		
+	</select>
+
+	<!-- 2024.10.29 권태성 휴일일자 검색 조건인 경우 searchKeyword를 formattedDtKeyword로 변경 -->
+	<select id="selectRestdeList" parameterType="egovframework.let.sym.cal.service.RestdeVO" resultType="egovMap">
+		
+			SELECT  *
+			  FROM  (
+			SELECT ROWNUM RNUM, ALL_LIST.*
+			  FROM  (
+			/* 구현 Sql */
+			SELECT  A.RESTDE_NO
+				 ,  A.RESTDE RESTDE_DE
+			     ,  A.RESTDE DBMS_KIND
+				 ,  A.RESTDE_NM
+				 ,  A.RESTDE_DC
+				 ,  B.CODE_NM        RESTDE_SE
+				 ,  A.RESTDE_SE_CODE
+			  FROM  COMTNRESTDE         A
+			     ,  COMTCCMMNDETAILCODE B
+			 WHERE  B.CODE_ID        = 'COM017'
+			   AND  A.RESTDE_SE_CODE = B.CODE
+		
+			<if test="searchCondition == 1">AND
+				A.RESTDE = #{formattedDtKeyword}
+			</if>
+			<if test="searchCondition == 2">AND
+				A.RESTDE_NM LIKE '%' || #{searchKeyword} || '%'
+			</if>
+		<![CDATA[
+			/* 구현 Sql */
+				    ) ALL_LIST
+				    ) Z
+			 WHERE  RNUM  > #{firstIndex}
+			   AND  RNUM <= #{firstIndex} + #{recordCountPerPage}
+		]]>
+	</select>
+
+	<!-- 2024.10.29 권태성 휴일일자 검색 조건인 경우 searchKeyword를 formattedDtKeyword로 변경 -->
+	<select id="selectRestdeListTotCnt" parameterType="egovframework.let.sym.cal.service.RestdeVO" resultType="int">
+		
+			SELECT  COUNT(*) totcnt
+			  FROM  COMTNRESTDE         A
+			     ,  COMTCCMMNDETAILCODE B
+			 WHERE  B.CODE_ID        = 'COM017'
+			   AND  A.RESTDE_SE_CODE = B.CODE
+		
+			<if test="searchCondition == 1">AND
+				RESTDE = #{formattedDtKeyword}
+			</if>
+			<if test="searchCondition == 2">AND
+				RESTDE_NM LIKE '%' || #{searchKeyword} || '%'
+			</if>
+	</select>
+
+	<insert id="insertRestde">
+		
+			INSERT
+			  INTO  COMTNRESTDE
+			     (  RESTDE_NO
+				 ,  RESTDE
+				 ,  RESTDE_NM
+				 ,  RESTDE_DC
+				 ,  RESTDE_SE_CODE
+			     ,  FRST_REGIST_PNTTM
+			     ,  FRST_REGISTER_ID
+			     ,  LAST_UPDT_PNTTM
+			     ,  LAST_UPDUSR_ID
+			     )
+			VALUES
+			     (  #{restdeNo}
+				 ,  #{restdeDe}
+				 ,  #{restdeNm}
+				 ,  #{restdeDc}
+				 ,  #{restdeSeCode}
+			     ,  SYSDATETIME
+			     ,  #{frstRegisterId}
+			     ,  SYSDATETIME
+			     ,  #{frstRegisterId}
+			     )
+		
+	</insert>
+
+	<select id="selectRestdeDetail" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovframework.let.sym.cal.service.Restde">
+		
+			SELECT  A.RESTDE_NO      restdeNo
+			     ,  A.RESTDE      restdeDe
+				 ,  A.RESTDE_NM      restdeNm
+				 ,  A.RESTDE_DC      restdeDc
+				 ,  B.CODE_NM        restdeSe
+				 ,  A.RESTDE_SE_CODE restdeSeCode
+			  FROM  COMTNRESTDE         A
+			     ,  COMTCCMMNDETAILCODE B
+			 WHERE  B.CODE_ID        = 'COM017'
+			   AND  A.RESTDE_SE_CODE = B.CODE
+               AND  A.RESTDE_NO      = #{restdeNo}
+		
+	</select>
+
+	<update id="updateRestde">
+		
+            UPDATE  COMTNRESTDE
+               SET  RESTDE_NM         = #{restdeNm}
+				 ,  RESTDE_DC         = #{restdeDc}
+				 ,  RESTDE_SE_CODE    = #{restdeSeCode}
+                 ,  LAST_UPDT_PNTTM = SYSDATETIME
+                 ,  LAST_UPDUSR_ID    = #{lastUpdusrId}
+             WHERE  RESTDE_NO         = #{restdeNo}
+		
+	</update>
+
+	<delete id="deleteRestde">
+		
+            DELETE
+              FROM  COMTNRESTDE
+             WHERE  RESTDE_NO = #{restdeNo}
+		
+	</delete>
+
+</mapper>

--- a/src/main/resources/egovframework/mapper/let/sym/cal/EgovRestdeManage_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/cal/EgovRestdeManage_SQL_hsql.xml
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
+"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="restdeManageDao">
+
+	<select id="selectNormalRestdePopup" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}               YEAR
+                 ,  #{month}              MONTH
+                 ,  CASE ((DUMMY.ROWNUM + 1 - #{startWeekMonth})>0 AND (DUMMY.ROWNUM + 1 - #{startWeekMonth}) &lt;= #{lastDayMonth})
+                    WHEN 1 THEN CAST((DUMMY.ROWNUM + 1 - #{startWeekMonth}) AS CHAR)
+                    ELSE ''
+                    END                  DAY
+                 ,  DUMMY.ROWNUM         CELL_NUM
+                 ,  DUMMY.WEEKS + 1      WEEKS
+                 ,  DUMMY.WEEK           WEEK
+                 ,  (
+                    SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE DUMMY.WEEK WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+                      FROM  COMTNRESTDE
+                     WHERE  RESTDE = CONCAT(#{year}
+                                              ,LPAD(#{month},2,'0')
+                                              ,LPAD(CASE((DUMMY.ROWNUM + 1 - #{startWeekMonth})>0 AND (DUMMY.ROWNUM + 1 - #{startWeekMonth}) &lt;= #{lastDayMonth})
+                                                    WHEN 1 THEN CAST((DUMMY.ROWNUM + 1 - #{startWeekMonth}) AS CHAR)
+                                                    ELSE ''
+                                                    END,2,'0'
+                                               )
+                                        )
+                       AND  RESTDE_SE_CODE IN ('01','02')
+                    ) REST_AT
+              FROM  (
+                    SELECT  (W.W*7) + D.D ROWNUM
+                         ,  W.W WEEKS
+                         ,  D.D WEEK
+                      FROM  (
+                            SELECT 0 W
+                            UNION ALL
+                            SELECT 1
+                            UNION ALL
+                            SELECT 2
+                            UNION ALL
+                            SELECT 3
+                            UNION ALL
+                            SELECT 4
+                            UNION ALL
+                            SELECT 5
+                            ) W,
+                            (
+                            SELECT 1 D
+                            UNION ALL
+                            SELECT 2
+                            UNION ALL
+                            SELECT 3
+                            UNION ALL
+                            SELECT 4
+                            UNION ALL
+                            SELECT 5
+                            UNION ALL
+                            SELECT 6
+                            UNION ALL
+                            SELECT 7
+                            ) D
+                    ORDER BY (W.W*7) + D.D
+            ) DUMMY
+			ORDER BY DUMMY.ROWNUM
+	</select>
+
+	<select id="selectAdministRestdePopup" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}               YEAR
+                 ,  #{month}               MONTH
+                 ,  CASE ((DUMMY.ROWNUM + 1 - #{startWeekMonth})>0 AND (DUMMY.ROWNUM + 1 - #{startWeekMonth}) &lt;= #{lastDayMonth})
+                    WHEN 1 THEN CAST((DUMMY.ROWNUM + 1 - #{startWeekMonth}) AS CHAR)
+                    ELSE ''
+                    END                  DAY
+                 ,  DUMMY.ROWNUM         CELL_NUM
+                 ,  DUMMY.WEEKS + 1      WEEKS
+                 ,  DUMMY.WEEK           WEEK
+                 ,  (
+                    SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE DUMMY.WEEK WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+                      FROM  COMTNRESTDE
+                     WHERE  RESTDE = CONCAT(#{year}
+                                              ,LPAD(#{month},2,'0')
+                                              ,LPAD(CASE((DUMMY.ROWNUM + 1 - #{startWeekMonth})>0 AND (DUMMY.ROWNUM + 1 - #{startWeekMonth}) &lt;= #{lastDayMonth})
+                                                    WHEN 1 THEN CAST((DUMMY.ROWNUM + 1 - #{startWeekMonth}) AS CHAR)
+                                                    ELSE ''
+                                                    END,2,'0'
+                                               )
+                                        )
+                       AND  RESTDE_SE_CODE IN ('02','03')
+                    ) REST_AT
+              FROM  (
+                    SELECT  (W.W*7) + D.D ROWNUM
+                         ,  W.W WEEKS
+                         ,  D.D WEEK
+                      FROM  (
+                            SELECT 0 W
+                            UNION ALL
+                            SELECT 1
+                            UNION ALL
+                            SELECT 2
+                            UNION ALL
+                            SELECT 3
+                            UNION ALL
+                            SELECT 4
+                            UNION ALL
+                            SELECT 5
+                            ) W,
+                            (
+                            SELECT 1 D
+                            UNION ALL
+                            SELECT 2
+                            UNION ALL
+                            SELECT 3
+                            UNION ALL
+                            SELECT 4
+                            UNION ALL
+                            SELECT 5
+                            UNION ALL
+                            SELECT 6
+                            UNION ALL
+                            SELECT 7
+                            ) D
+                    ORDER BY (W.W*7) + D.D
+            ) DUMMY
+			ORDER BY DUMMY.ROWNUMf
+	</select>
+
+	<select id="selectNormalDayCal" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+			SELECT  #{year}               YEAR
+			     ,  #{month}              MONTH
+				 ,  #{day}                DAY
+				 ,  #{week}               WEEK
+				 ,  #{weeks}              WEEKS
+				 ,  #{maxWeeks}           MAX_WEEKS
+				 ,  #{lastDayMonth}       LAST_DAY_MONTH
+			     ,  (	SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE #{week} WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+			              FROM  COMTNRESTDE
+			             WHERE  RESTDE = CONCAT(#{year},LPAD(#{month},2,'0'),LPAD(#{day},2,'0'))
+			               AND  RESTDE_SE_CODE IN ('01','02')
+			        ) REST_AT
+		
+	</select>
+
+	<select id="selectNormalDayRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}     YEAR
+                 ,  #{month}    MONTH
+                 ,  #{day}      DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE
+             WHERE  RESTDE         = CONCAT(#{year},LPAD(#{month},2,'0'),LPAD(#{day},2,'0'))
+               AND  RESTDE_SE_CODE   IN ('01','02')
+		
+	</select>
+
+	<select id="selectNormalMonthRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}                YEAR
+                 ,  #{month}               MONTH
+                 ,  CAST(CAST( SUBSTR(RESTDE,7,2) AS DECIMAL(2)) AS CHAR) DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE
+             WHERE  RESTDE      LIKE CONCAT(#{year},LPAD(#{month},2,'0'),'%')
+               AND  RESTDE_SE_CODE   IN ('01','02')
+		
+	</select>
+
+	<select id="selectAdministDayCal" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+			SELECT  #{year}               YEAR
+			     ,  #{month}              MONTH
+				 ,  #{day}                DAY
+				 ,  #{week}               WEEK
+				 ,  #{weeks}              WEEKS
+				 ,  #{maxWeeks}           MAX_WEEKS
+				 ,  #{lastDayMonth}       LAST_DAY_MONTH
+			     ,  (	SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE #{week} WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+			              FROM  COMTNRESTDE
+			             WHERE  RESTDE = CONCAT(#{year},LPAD(#{month},2,'0'),LPAD(#{day},2,'0'))
+			               AND  RESTDE_SE_CODE IN ('02','03')
+			        ) REST_AT
+		
+	</select>
+
+	<select id="selectAdministDayRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}     YEAR
+                 ,  #{month}    MONTH
+                 ,  #{day}      DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE
+             WHERE  RESTDE         = CONCAT(#{year},LPAD(#{month},2,'0'),LPAD(#{day},2,'0'))
+               AND  RESTDE_SE_CODE   IN ('02','03')
+		
+	</select>
+
+	<select id="selectAdministMonthRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}                YEAR
+                 ,  #{month}               MONTH
+                 ,  CAST(CAST( SUBSTR(RESTDE,7,2) AS DECIMAL(2)) AS CHAR) DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE
+             WHERE  RESTDE      LIKE CONCAT(#{year},LPAD(#{month},2,'0'),'%')
+               AND  RESTDE_SE_CODE   IN ('02','03')
+		
+	</select>
+
+	<!-- 2024.10.29 권태성 휴일일자 검색 조건인 경우 searchKeyword를 formattedDtKeyword로 변경 -->
+	<select id="selectRestdeList" parameterType="egovframework.let.sym.cal.service.RestdeVO" resultType="egovMap">
+		
+			SELECT  A.RESTDE_NO
+			     ,  A.RESTDE RESTDE_DE
+				 ,  A.RESTDE_NM
+				 ,  A.RESTDE_DC
+				 ,  B.CODE_NM        RESTDE_SE
+				 ,  A.RESTDE_SE_CODE
+			  FROM  COMTNRESTDE         A
+			     ,  COMTCCMMNDETAILCODE B
+			 WHERE  B.CODE_ID        = 'COM017'
+			   AND  A.RESTDE_SE_CODE = B.CODE
+		
+			<if test="searchCondition == 1">AND
+				A.RESTDE = #{formattedDtKeyword}
+			</if>
+			<if test="searchCondition == 2">AND
+				A.RESTDE_NM LIKE CONCAT ('%', #{searchKeyword},'%')
+			</if>
+			 LIMIT  #{recordCountPerPage} OFFSET #{firstIndex}
+	</select>
+
+	<!-- 2024.10.29 권태성 휴일일자 검색 조건인 경우 searchKeyword를 formattedDtKeyword로 변경 -->
+	<select id="selectRestdeListTotCnt" parameterType="egovframework.let.sym.cal.service.RestdeVO" resultType="int">
+		
+			SELECT  COUNT(*) totcnt
+			  FROM  COMTNRESTDE         A
+			     ,  COMTCCMMNDETAILCODE B
+			 WHERE  B.CODE_ID        = 'COM017'
+			   AND  A.RESTDE_SE_CODE = B.CODE
+		
+			<if test="searchCondition == 1">AND
+				RESTDE = #{formattedDtKeyword}
+			</if>
+			<if test="searchCondition == 2">AND
+				RESTDE_NM LIKE CONCAT ('%', #{searchKeyword},'%')
+			</if>
+	</select>
+
+	<insert id="insertRestde">
+		
+			INSERT
+			  INTO  COMTNRESTDE
+			     (  RESTDE_NO
+				 ,  RESTDE
+				 ,  RESTDE_NM
+				 ,  RESTDE_DC
+				 ,  RESTDE_SE_CODE
+			     ,  FRST_REGIST_PNTTM
+			     ,  FRST_REGISTER_ID
+			     ,  LAST_UPDT_PNTTM
+			     ,  LAST_UPDUSR_ID
+			     )
+			VALUES
+			     (  #{restdeNo}
+				 ,  #{restdeDe}
+				 ,  #{restdeNm}
+				 ,  #{restdeDc}
+				 ,  #{restdeSeCode}
+			     ,  SYSDATE()
+			     ,  #{frstRegisterId}
+			     ,  SYSDATE()
+			     ,  #{frstRegisterId}
+			     )
+		
+	</insert>
+
+	<select id="selectRestdeDetail" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovframework.let.sym.cal.service.Restde">
+		
+			SELECT  A.RESTDE_NO      restdeNo
+			     ,  A.RESTDE      restdeDe
+				 ,  A.RESTDE_NM      restdeNm
+				 ,  A.RESTDE_DC      restdeDc
+				 ,  B.CODE_NM        restdeSe
+				 ,  A.RESTDE_SE_CODE restdeSeCode
+			  FROM  COMTNRESTDE         A
+			     ,  COMTCCMMNDETAILCODE B
+			 WHERE  B.CODE_ID        = 'COM017'
+			   AND  A.RESTDE_SE_CODE = B.CODE
+               AND  A.RESTDE_NO      = #{restdeNo}
+		
+	</select>
+
+	<update id="updateRestde">
+		
+            UPDATE  COMTNRESTDE
+               SET  RESTDE_NM         = #{restdeNm}
+				 ,  RESTDE_DC         = #{restdeDc}
+				 ,  RESTDE_SE_CODE    = #{restdeSeCode}
+                 ,  LAST_UPDT_PNTTM = sysdate()
+                 ,  LAST_UPDUSR_ID    = #{lastUpdusrId}
+             WHERE  RESTDE_NO         = #{restdeNo}
+		
+	</update>
+
+	<delete id="deleteRestde">
+		
+            DELETE
+              FROM  COMTNRESTDE
+             WHERE  RESTDE_NO = #{restdeNo}
+		
+	</delete>
+
+</mapper>

--- a/src/main/resources/egovframework/mapper/let/sym/cal/EgovRestdeManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/cal/EgovRestdeManage_SQL_mysql.xml
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
+"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="restdeManageDao">
+
+	<select id="selectNormalRestdePopup" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}               YEAR
+                 ,  #{month}              MONTH
+                 ,  CASE ((DUMMY.ROWNUM + 1 - #{startWeekMonth})>0 AND (DUMMY.ROWNUM + 1 - #{startWeekMonth}) &lt;= #{lastDayMonth})
+                    WHEN 1 THEN CAST((DUMMY.ROWNUM + 1 - #{startWeekMonth}) AS CHAR)
+                    ELSE ''
+                    END                  DAY
+                 ,  DUMMY.ROWNUM         CELL_NUM
+                 ,  DUMMY.WEEKS + 1      WEEKS
+                 ,  DUMMY.WEEK           WEEK
+                 ,  (
+                    SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE DUMMY.WEEK WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+                      FROM  COMTNRESTDE
+                     WHERE  RESTDE = CONCAT(#{year}
+                                              ,LPAD(#{month},2,'0')
+                                              ,LPAD(CASE((DUMMY.ROWNUM + 1 - #{startWeekMonth})>0 AND (DUMMY.ROWNUM + 1 - #{startWeekMonth}) &lt;= #{lastDayMonth})
+                                                    WHEN 1 THEN CAST((DUMMY.ROWNUM + 1 - #{startWeekMonth}) AS CHAR)
+                                                    ELSE ''
+                                                    END,2,'0'
+                                               )
+                                        )
+                       AND  RESTDE_SE_CODE IN ('01','02')
+                    ) REST_AT
+              FROM  (
+                    SELECT  (W.W*7) + D.D ROWNUM
+                         ,  W.W WEEKS
+                         ,  D.D WEEK
+                      FROM  (
+                            SELECT 0 W
+                            UNION ALL
+                            SELECT 1
+                            UNION ALL
+                            SELECT 2
+                            UNION ALL
+                            SELECT 3
+                            UNION ALL
+                            SELECT 4
+                            UNION ALL
+                            SELECT 5
+                            ) W,
+                            (
+                            SELECT 1 D
+                            UNION ALL
+                            SELECT 2
+                            UNION ALL
+                            SELECT 3
+                            UNION ALL
+                            SELECT 4
+                            UNION ALL
+                            SELECT 5
+                            UNION ALL
+                            SELECT 6
+                            UNION ALL
+                            SELECT 7
+                            ) D
+                    ORDER BY (W.W*7) + D.D
+            ) DUMMY
+			ORDER BY DUMMY.ROWNUM
+	</select>
+
+	<select id="selectAdministRestdePopup" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}               YEAR
+                 ,  #{month}               MONTH
+                 ,  CASE ((DUMMY.ROWNUM + 1 - #{startWeekMonth})>0 AND (DUMMY.ROWNUM + 1 - #{startWeekMonth}) &lt;= #{lastDayMonth})
+                    WHEN 1 THEN CAST((DUMMY.ROWNUM + 1 - #{startWeekMonth}) AS CHAR)
+                    ELSE ''
+                    END                  DAY
+                 ,  DUMMY.ROWNUM         CELL_NUM
+                 ,  DUMMY.WEEKS + 1      WEEKS
+                 ,  DUMMY.WEEK           WEEK
+                 ,  (
+                    SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE DUMMY.WEEK WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+                      FROM  COMTNRESTDE
+                     WHERE  RESTDE = CONCAT(#{year}
+                                              ,LPAD(#{month},2,'0')
+                                              ,LPAD(CASE((DUMMY.ROWNUM + 1 - #{startWeekMonth})>0 AND (DUMMY.ROWNUM + 1 - #{startWeekMonth}) &lt;= #{lastDayMonth})
+                                                    WHEN 1 THEN CAST((DUMMY.ROWNUM + 1 - #{startWeekMonth}) AS CHAR)
+                                                    ELSE ''
+                                                    END,2,'0'
+                                               )
+                                        )
+                       AND  RESTDE_SE_CODE IN ('02','03')
+                    ) REST_AT
+              FROM  (
+                    SELECT  (W.W*7) + D.D ROWNUM
+                         ,  W.W WEEKS
+                         ,  D.D WEEK
+                      FROM  (
+                            SELECT 0 W
+                            UNION ALL
+                            SELECT 1
+                            UNION ALL
+                            SELECT 2
+                            UNION ALL
+                            SELECT 3
+                            UNION ALL
+                            SELECT 4
+                            UNION ALL
+                            SELECT 5
+                            ) W,
+                            (
+                            SELECT 1 D
+                            UNION ALL
+                            SELECT 2
+                            UNION ALL
+                            SELECT 3
+                            UNION ALL
+                            SELECT 4
+                            UNION ALL
+                            SELECT 5
+                            UNION ALL
+                            SELECT 6
+                            UNION ALL
+                            SELECT 7
+                            ) D
+                    ORDER BY (W.W*7) + D.D
+            ) DUMMY
+			ORDER BY DUMMY.ROWNUMf
+	</select>
+
+	<select id="selectNormalDayCal" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+			SELECT  #{year}               YEAR
+			     ,  #{month}              MONTH
+				 ,  #{day}                DAY
+				 ,  #{week}               WEEK
+				 ,  #{weeks}              WEEKS
+				 ,  #{maxWeeks}           MAX_WEEKS
+				 ,  #{lastDayMonth}       LAST_DAY_MONTH
+			     ,  (	SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE #{week} WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+			              FROM  COMTNRESTDE
+			             WHERE  RESTDE = CONCAT(#{year},LPAD(#{month},2,'0'),LPAD(#{day},2,'0'))
+			               AND  RESTDE_SE_CODE IN ('01','02')
+			        ) REST_AT
+		
+	</select>
+
+	<select id="selectNormalDayRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}     YEAR
+                 ,  #{month}    MONTH
+                 ,  #{day}      DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE
+             WHERE  RESTDE         = CONCAT(#{year},LPAD(#{month},2,'0'),LPAD(#{day},2,'0'))
+               AND  RESTDE_SE_CODE   IN ('01','02')
+		
+	</select>
+
+	<select id="selectNormalMonthRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}                YEAR
+                 ,  #{month}               MONTH
+                 ,  CAST(CAST( SUBSTR(RESTDE,7,2) AS DECIMAL(2)) AS CHAR) DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE
+             WHERE  RESTDE      LIKE CONCAT(#{year},LPAD(#{month},2,'0'),'%')
+               AND  RESTDE_SE_CODE   IN ('01','02')
+		
+	</select>
+
+	<select id="selectAdministDayCal" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+			SELECT  #{year}               YEAR
+			     ,  #{month}              MONTH
+				 ,  #{day}                DAY
+				 ,  #{week}               WEEK
+				 ,  #{weeks}              WEEKS
+				 ,  #{maxWeeks}           MAX_WEEKS
+				 ,  #{lastDayMonth}       LAST_DAY_MONTH
+			     ,  (	SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE #{week} WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+			              FROM  COMTNRESTDE
+			             WHERE  RESTDE = CONCAT(#{year},LPAD(#{month},2,'0'),LPAD(#{day},2,'0'))
+			               AND  RESTDE_SE_CODE IN ('02','03')
+			        ) REST_AT
+		
+	</select>
+
+	<select id="selectAdministDayRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}     YEAR
+                 ,  #{month}    MONTH
+                 ,  #{day}      DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE
+             WHERE  RESTDE         = CONCAT(#{year},LPAD(#{month},2,'0'),LPAD(#{day},2,'0'))
+               AND  RESTDE_SE_CODE   IN ('02','03')
+		
+	</select>
+
+	<select id="selectAdministMonthRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}                YEAR
+                 ,  #{month}               MONTH
+                 ,  CAST(CAST( SUBSTR(RESTDE,7,2) AS DECIMAL(2)) AS CHAR) DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE
+             WHERE  RESTDE      LIKE CONCAT(#{year},LPAD(#{month},2,'0'),'%')
+               AND  RESTDE_SE_CODE   IN ('02','03')
+		
+	</select>
+
+	<!-- 2024.10.29 권태성 휴일일자 검색 조건인 경우 searchKeyword를 formattedDtKeyword로 변경 -->
+	<select id="selectRestdeList" parameterType="egovframework.let.sym.cal.service.RestdeVO" resultType="egovMap">
+		
+			SELECT  A.RESTDE_NO
+			     ,  A.RESTDE RESTDE_DE
+				 ,  A.RESTDE_NM
+				 ,  A.RESTDE_DC
+				 ,  B.CODE_NM        RESTDE_SE
+				 ,  A.RESTDE_SE_CODE
+			  FROM  COMTNRESTDE         A
+			     ,  COMTCCMMNDETAILCODE B
+			 WHERE  B.CODE_ID        = 'COM017'
+			   AND  A.RESTDE_SE_CODE = B.CODE
+		
+			<if test="searchCondition == 1">AND
+				A.RESTDE = #{formattedDtKeyword}
+			</if>
+			<if test="searchCondition == 2">AND
+				A.RESTDE_NM LIKE CONCAT ('%', #{searchKeyword},'%')
+			</if>
+			 LIMIT  #{recordCountPerPage} OFFSET #{firstIndex}
+	</select>
+
+	<!-- 2024.10.29 권태성 휴일일자 검색 조건인 경우 searchKeyword를 formattedDtKeyword로 변경 -->
+	<select id="selectRestdeListTotCnt" parameterType="egovframework.let.sym.cal.service.RestdeVO" resultType="int">
+		
+			SELECT  COUNT(*) totcnt
+			  FROM  COMTNRESTDE         A
+			     ,  COMTCCMMNDETAILCODE B
+			 WHERE  B.CODE_ID        = 'COM017'
+			   AND  A.RESTDE_SE_CODE = B.CODE
+		
+			<if test="searchCondition == 1">AND
+				RESTDE = #{formattedDtKeyword}
+			</if>
+			<if test="searchCondition == 2">AND
+				RESTDE_NM LIKE CONCAT ('%', #{searchKeyword},'%')
+			</if>
+	</select>
+
+	<insert id="insertRestde">
+		
+			INSERT
+			  INTO  COMTNRESTDE
+			     (  RESTDE_NO
+				 ,  RESTDE
+				 ,  RESTDE_NM
+				 ,  RESTDE_DC
+				 ,  RESTDE_SE_CODE
+			     ,  FRST_REGIST_PNTTM
+			     ,  FRST_REGISTER_ID
+			     ,  LAST_UPDT_PNTTM
+			     ,  LAST_UPDUSR_ID
+			     )
+			VALUES
+			     (  #{restdeNo}
+				 ,  #{restdeDe}
+				 ,  #{restdeNm}
+				 ,  #{restdeDc}
+				 ,  #{restdeSeCode}
+			     ,  SYSDATE()
+			     ,  #{frstRegisterId}
+			     ,  SYSDATE()
+			     ,  #{frstRegisterId}
+			     )
+		
+	</insert>
+
+	<select id="selectRestdeDetail" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovframework.let.sym.cal.service.Restde">
+		
+			SELECT  A.RESTDE_NO      restdeNo
+			     ,  A.RESTDE      restdeDe
+				 ,  A.RESTDE_NM      restdeNm
+				 ,  A.RESTDE_DC      restdeDc
+				 ,  B.CODE_NM        restdeSe
+				 ,  A.RESTDE_SE_CODE restdeSeCode
+			  FROM  COMTNRESTDE         A
+			     ,  COMTCCMMNDETAILCODE B
+			 WHERE  B.CODE_ID        = 'COM017'
+			   AND  A.RESTDE_SE_CODE = B.CODE
+               AND  A.RESTDE_NO      = #{restdeNo}
+		
+	</select>
+
+	<update id="updateRestde">
+		
+            UPDATE  COMTNRESTDE
+               SET  RESTDE_NM         = #{restdeNm}
+				 ,  RESTDE_DC         = #{restdeDc}
+				 ,  RESTDE_SE_CODE    = #{restdeSeCode}
+                 ,  LAST_UPDT_PNTTM = sysdate()
+                 ,  LAST_UPDUSR_ID    = #{lastUpdusrId}
+             WHERE  RESTDE_NO         = #{restdeNo}
+		
+	</update>
+
+	<delete id="deleteRestde">
+		
+            DELETE
+              FROM  COMTNRESTDE
+             WHERE  RESTDE_NO = #{restdeNo}
+		
+	</delete>
+
+</mapper>

--- a/src/main/resources/egovframework/mapper/let/sym/cal/EgovRestdeManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/cal/EgovRestdeManage_SQL_oracle.xml
@@ -1,0 +1,324 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
+"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="restdeManageDao">
+
+	<select id="selectNormalRestdePopup" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}               YEAR
+                 ,  #{month}              MONTH
+                 ,  DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},0),0,'',DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},#{lastDayMonth}),#{lastDayMonth},TO_CHAR(T_DUMMY.RNUM + 1 - #{startWeekMonth}),''))
+                                         DAY 
+                 ,  T_DUMMY.RNUM           CELL_NUM
+                 ,  T_DUMMY.WEEKS + 1      WEEKS
+                 ,  T_DUMMY.WEEK           WEEK
+                 ,  (
+                    SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE T_DUMMY.WEEK WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+                      FROM  COMTNRESTDE 
+                     WHERE  RESTDE = LPAD(#{year},4,'0')
+                                      ||LPAD(#{month},2,'0')
+                                      ||LPAD(DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},0),0,'',DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},#{lastDayMonth}),#{lastDayMonth},TO_CHAR(T_DUMMY.RNUM + 1 - #{startWeekMonth}),''))
+                    			             ,2,'0'
+                    			            )
+                       AND  RESTDE_SE_CODE IN ('01','02')                                   
+                    ) REST_AT
+              FROM  (
+                    SELECT  (W.W*7) + D.D RNUM
+                         ,  W.W WEEKS
+                         ,  D.D WEEK
+                      FROM  (
+						    SELECT 0 W  FROM DUAL
+						    UNION ALL
+						    SELECT 1 FROM DUAL
+						    UNION ALL
+						    SELECT 2 FROM DUAL
+						    UNION ALL
+						    SELECT 3 FROM DUAL
+						    UNION ALL
+						    SELECT 4 FROM DUAL
+						    UNION ALL
+						    SELECT 5 FROM DUAL
+						    ) W,
+						    (
+						    SELECT 1 D FROM DUAL
+						    UNION ALL
+						    SELECT 2 FROM DUAL
+						    UNION ALL
+						    SELECT 3 FROM DUAL
+						    UNION ALL
+						    SELECT 4 FROM DUAL
+						    UNION ALL
+						    SELECT 5 FROM DUAL
+						    UNION ALL
+						    SELECT 6 FROM DUAL
+						    UNION ALL
+						    SELECT 7 FROM DUAL
+                            ) D
+                    ORDER BY (W.W*7) + D.D
+            ) T_DUMMY
+			ORDER BY T_DUMMY.RNUM            
+		
+	</select>
+
+	<select id="selectAdministRestdePopup" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}               YEAR
+                 ,  #{month}              MONTH
+                 ,  DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},0),0,'',DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},#{lastDayMonth}),#{lastDayMonth},TO_CHAR(T_DUMMY.RNUM + 1 - #{startWeekMonth}),''))
+                                         DAY 
+                 ,  T_DUMMY.RNUM           CELL_NUM
+                 ,  T_DUMMY.WEEKS + 1      WEEKS
+                 ,  T_DUMMY.WEEK           WEEK
+                 ,  (
+                    SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE T_DUMMY.WEEK WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+                      FROM  COMTNRESTDE 
+                     WHERE  RESTDE = LPAD(#{year},4,'0')
+                                      ||LPAD(#{month},2,'0')
+                                      ||LPAD(DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},0),0,'',DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},#{lastDayMonth}),#{lastDayMonth},TO_CHAR(T_DUMMY.RNUM + 1 - #{startWeekMonth}),''))
+                    			             ,2,'0'
+                    			            )
+                       AND  RESTDE_SE_CODE IN ('02','03')                                   
+                    ) REST_AT
+              FROM  (
+                    SELECT  (W.W*7) + D.D RNUM
+                         ,  W.W WEEKS
+                         ,  D.D WEEK
+                      FROM  (
+						    SELECT 0 W  FROM DUAL
+						    UNION ALL
+						    SELECT 1 FROM DUAL
+						    UNION ALL
+						    SELECT 2 FROM DUAL
+						    UNION ALL
+						    SELECT 3 FROM DUAL
+						    UNION ALL
+						    SELECT 4 FROM DUAL
+						    UNION ALL
+						    SELECT 5 FROM DUAL
+						    ) W,
+						    (
+						    SELECT 1 D FROM DUAL
+						    UNION ALL
+						    SELECT 2 FROM DUAL
+						    UNION ALL
+						    SELECT 3 FROM DUAL
+						    UNION ALL
+						    SELECT 4 FROM DUAL
+						    UNION ALL
+						    SELECT 5 FROM DUAL
+						    UNION ALL
+						    SELECT 6 FROM DUAL
+						    UNION ALL
+						    SELECT 7 FROM DUAL
+                            ) D
+                    ORDER BY (W.W*7) + D.D
+            ) T_DUMMY
+			ORDER BY T_DUMMY.RNUM            
+		
+	</select>
+
+	<select id="selectNormalDayCal" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+			SELECT  #{year}               YEAR
+			     ,  #{month}              MONTH
+				 ,  #{day}                DAY
+				 ,  #{week}                 WEEK
+				 ,  #{weeks}                WEEKS
+				 ,  #{maxWeeks}             MAX_WEEKS
+				 ,  #{lastDayMonth}         LAST_DAY_MONTH
+			     ,  (	SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE #{week} WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+			              FROM  COMTNRESTDE 
+			             WHERE  RESTDE = LPAD(#{year},4,'0')||LPAD(#{month},2,'0')||LPAD(#{day},2,'0')
+			               AND  RESTDE_SE_CODE IN ('01','02')                                   
+			        ) REST_AT
+			  FROM  DUAL      
+		
+	</select>
+	
+	<select id="selectNormalDayRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}     YEAR
+                 ,  #{month}    MONTH
+                 ,  #{day}      DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE 
+             WHERE  RESTDE         = LPAD(#{year},4,'0')||LPAD(#{month},2,'0')||LPAD(#{day},2,'0')
+               AND  RESTDE_SE_CODE   IN ('01','02')       
+		
+	</select>
+
+	<select id="selectNormalMonthRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}                YEAR
+                 ,  #{month}               MONTH
+                 ,  TO_CHAR(TO_NUMBER( SUBSTR(RESTDE,7,2))) DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE 
+             WHERE  RESTDE      LIKE LPAD(#{year},4,'0')||LPAD(#{month},2,'0')||'%'
+               AND  RESTDE_SE_CODE   IN ('01','02')       
+		
+	</select>
+
+	<select id="selectAdministDayCal" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+			SELECT  #{year}               YEAR
+			     ,  #{month}              MONTH
+				 ,  #{day}                DAY
+				 ,  #{week}                 WEEK
+				 ,  #{weeks}                WEEKS
+				 ,  #{maxWeeks}             MAX_WEEKS
+				 ,  #{lastDayMonth}         LAST_DAY_MONTH
+			     ,  (	SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE #{week} WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+			              FROM  COMTNRESTDE 
+			             WHERE  RESTDE = LPAD(#{year},4,'0')||LPAD(#{month},2,'0')||LPAD(#{day},2,'0')
+			               AND  RESTDE_SE_CODE IN ('02','03')                                   
+			        ) REST_AT
+			  FROM  DUAL      
+		
+	</select>
+	
+	<select id="selectAdministDayRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}     YEAR
+                 ,  #{month}    MONTH
+                 ,  #{day}      DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE 
+             WHERE  RESTDE         = LPAD(#{year},4,'0')||LPAD(#{month},2,'0')||LPAD(#{day},2,'0')
+               AND  RESTDE_SE_CODE   IN ('02','03')       
+		
+	</select>
+
+	<select id="selectAdministMonthRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}                YEAR
+                 ,  #{month}               MONTH
+                 ,  TO_CHAR(TO_NUMBER(SUBSTR(RESTDE,7,2))) DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE 
+             WHERE  RESTDE      LIKE LPAD(#{year},4,'0')||LPAD(#{month},2,'0')||'%'
+               AND  RESTDE_SE_CODE   IN ('02','03')       
+		
+	</select>
+
+	<!-- 2024.10.29 권태성 휴일일자 검색 조건인 경우 searchKeyword를 formattedDtKeyword로 변경 -->
+	<select id="selectRestdeList" parameterType="egovframework.let.sym.cal.service.RestdeVO" resultType="egovMap">
+		
+			SELECT  * 
+			  FROM  (
+			SELECT ROWNUM RNUM, ALL_LIST.* 
+			  FROM  (
+			/* 구현 Sql */
+			SELECT  A.RESTDE_NO
+				 ,  A.RESTDE RESTDE_DE
+			     ,  A.RESTDE DBMS_KIND
+				 ,  A.RESTDE_NM
+				 ,  A.RESTDE_DC
+				 ,  B.CODE_NM        RESTDE_SE
+				 ,  A.RESTDE_SE_CODE
+			  FROM  COMTNRESTDE         A
+			     ,  COMTCCMMNDETAILCODE B
+			 WHERE  B.CODE_ID        = 'COM017'
+			   AND  A.RESTDE_SE_CODE = B.CODE
+		
+			<if test="searchCondition == 1">AND
+				A.RESTDE = #{formattedDtKeyword}
+			</if>
+			<if test="searchCondition == 2">AND
+				A.RESTDE_NM LIKE '%' || #{searchKeyword} || '%'
+			</if>
+		<![CDATA[
+			/* 구현 Sql */
+				    ) ALL_LIST
+				    )
+			 WHERE  RNUM  > #{firstIndex}
+			   AND  RNUM <= #{firstIndex} + #{recordCountPerPage}
+		]]>
+	</select>
+
+	<!-- 2024.10.29 권태성 휴일일자 검색 조건인 경우 searchKeyword를 formattedDtKeyword로 변경 -->
+	<select id="selectRestdeListTotCnt" parameterType="egovframework.let.sym.cal.service.RestdeVO" resultType="int">
+		
+			SELECT  COUNT(*) totcnt 
+			  FROM  COMTNRESTDE         A
+			     ,  COMTCCMMNDETAILCODE B
+			 WHERE  B.CODE_ID        = 'COM017'
+			   AND  A.RESTDE_SE_CODE = B.CODE
+		
+			<if test="searchCondition == 1">AND
+				RESTDE = #{formattedDtKeyword}
+			</if>
+			<if test="searchCondition == 2">AND
+				RESTDE_NM LIKE '%' || #{searchKeyword} || '%'
+			</if>
+	</select>
+
+	<insert id="insertRestde">
+		
+			INSERT 
+			  INTO  COMTNRESTDE
+			     (  RESTDE_NO
+				 ,  RESTDE
+				 ,  RESTDE_NM
+				 ,  RESTDE_DC
+				 ,  RESTDE_SE_CODE
+			     ,  FRST_REGIST_PNTTM
+			     ,  FRST_REGISTER_ID
+			     ,  LAST_UPDT_PNTTM
+			     ,  LAST_UPDUSR_ID
+			     ) 
+			VALUES
+			     (  #{restdeNo}
+				 ,  #{restdeDe}
+				 ,  #{restdeNm}
+				 ,  #{restdeDc}
+				 ,  #{restdeSeCode}
+			     ,  SYSDATE
+			     ,  #{frstRegisterId}
+			     ,  SYSDATE
+			     ,  #{frstRegisterId}
+			     ) 
+		
+	</insert>
+
+	<select id="selectRestdeDetail" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovframework.let.sym.cal.service.Restde">
+		
+			SELECT  A.RESTDE_NO      restdeNo
+			     ,  A.RESTDE      restdeDe
+				 ,  A.RESTDE_NM      restdeNm
+				 ,  A.RESTDE_DC      restdeDc
+				 ,  B.CODE_NM        restdeSe
+				 ,  A.RESTDE_SE_CODE restdeSeCode
+			  FROM  COMTNRESTDE         A
+			     ,  COMTCCMMNDETAILCODE B
+			 WHERE  B.CODE_ID        = 'COM017'
+			   AND  A.RESTDE_SE_CODE = B.CODE
+               AND  A.RESTDE_NO      = #{restdeNo}
+		
+	</select>
+
+	<update id="updateRestde">
+		
+            UPDATE  COMTNRESTDE 
+               SET  RESTDE_NM         = #{restdeNm}
+				 ,  RESTDE_DC         = #{restdeDc}
+				 ,  RESTDE_SE_CODE    = #{restdeSeCode}
+                 ,  LAST_UPDT_PNTTM = sysdate
+                 ,  LAST_UPDUSR_ID    = #{lastUpdusrId}
+             WHERE  RESTDE_NO         = #{restdeNo}
+		
+	</update>
+
+	<delete id="deleteRestde">
+		
+            DELETE  
+              FROM  COMTNRESTDE     
+             WHERE  RESTDE_NO = #{restdeNo}
+		
+	</delete>
+	
+</mapper>

--- a/src/main/resources/egovframework/mapper/let/sym/cal/EgovRestdeManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/cal/EgovRestdeManage_SQL_tibero.xml
@@ -1,0 +1,323 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
+"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="restdeManageDao">
+	<select id="selectNormalRestdePopup" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}               YEAR
+                 ,  #{month}              MONTH
+                 ,  DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},0),0,'',DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},#{lastDayMonth}),#{lastDayMonth},TO_CHAR(T_DUMMY.RNUM + 1 - #{startWeekMonth}),''))
+                                         DAY 
+                 ,  T_DUMMY.RNUM           CELL_NUM
+                 ,  T_DUMMY.WEEKS + 1      WEEKS
+                 ,  T_DUMMY.WEEK           WEEK
+                 ,  (
+                    SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE T_DUMMY.WEEK WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+                      FROM  COMTNRESTDE 
+                     WHERE  RESTDE = LPAD(#{year},4,'0')
+                                      ||LPAD(#{month},2,'0')
+                                      ||LPAD(DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},0),0,'',DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},#{lastDayMonth}),#{lastDayMonth},TO_CHAR(T_DUMMY.RNUM + 1 - #{startWeekMonth}),''))
+                    			             ,2,'0'
+                    			            )
+                       AND  RESTDE_SE_CODE IN ('01','02')                                   
+                    ) REST_AT
+              FROM  (
+                    SELECT  (W.W*7) + D.D RNUM
+                         ,  W.W WEEKS
+                         ,  D.D WEEK
+                      FROM  (
+						    SELECT 0 W  FROM DUAL
+						    UNION ALL
+						    SELECT 1 FROM DUAL
+						    UNION ALL
+						    SELECT 2 FROM DUAL
+						    UNION ALL
+						    SELECT 3 FROM DUAL
+						    UNION ALL
+						    SELECT 4 FROM DUAL
+						    UNION ALL
+						    SELECT 5 FROM DUAL
+						    ) W,
+						    (
+						    SELECT 1 D FROM DUAL
+						    UNION ALL
+						    SELECT 2 FROM DUAL
+						    UNION ALL
+						    SELECT 3 FROM DUAL
+						    UNION ALL
+						    SELECT 4 FROM DUAL
+						    UNION ALL
+						    SELECT 5 FROM DUAL
+						    UNION ALL
+						    SELECT 6 FROM DUAL
+						    UNION ALL
+						    SELECT 7 FROM DUAL
+                            ) D
+                    ORDER BY (W.W*7) + D.D
+            ) T_DUMMY
+			ORDER BY T_DUMMY.RNUM            
+		
+	</select>
+
+	<select id="selectAdministRestdePopup" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}               YEAR
+                 ,  #{month}              MONTH
+                 ,  DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},0),0,'',DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},#{lastDayMonth}),#{lastDayMonth},TO_CHAR(T_DUMMY.RNUM + 1 - #{startWeekMonth}),''))
+                                         DAY 
+                 ,  T_DUMMY.RNUM           CELL_NUM
+                 ,  T_DUMMY.WEEKS + 1      WEEKS
+                 ,  T_DUMMY.WEEK           WEEK
+                 ,  (
+                    SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE T_DUMMY.WEEK WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+                      FROM  COMTNRESTDE 
+                     WHERE  RESTDE = LPAD(#{year},4,'0')
+                                      ||LPAD(#{month},2,'0')
+                                      ||LPAD(DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},0),0,'',DECODE(GREATEST(T_DUMMY.RNUM + 1 - #{startWeekMonth},#{lastDayMonth}),#{lastDayMonth},TO_CHAR(T_DUMMY.RNUM + 1 - #{startWeekMonth}),''))
+                    			             ,2,'0'
+                    			            )
+                       AND  RESTDE_SE_CODE IN ('02','03')                                   
+                    ) REST_AT
+              FROM  (
+                    SELECT  (W.W*7) + D.D RNUM
+                         ,  W.W WEEKS
+                         ,  D.D WEEK
+                      FROM  (
+						    SELECT 0 W  FROM DUAL
+						    UNION ALL
+						    SELECT 1 FROM DUAL
+						    UNION ALL
+						    SELECT 2 FROM DUAL
+						    UNION ALL
+						    SELECT 3 FROM DUAL
+						    UNION ALL
+						    SELECT 4 FROM DUAL
+						    UNION ALL
+						    SELECT 5 FROM DUAL
+						    ) W,
+						    (
+						    SELECT 1 D FROM DUAL
+						    UNION ALL
+						    SELECT 2 FROM DUAL
+						    UNION ALL
+						    SELECT 3 FROM DUAL
+						    UNION ALL
+						    SELECT 4 FROM DUAL
+						    UNION ALL
+						    SELECT 5 FROM DUAL
+						    UNION ALL
+						    SELECT 6 FROM DUAL
+						    UNION ALL
+						    SELECT 7 FROM DUAL
+                            ) D
+                    ORDER BY (W.W*7) + D.D
+            ) T_DUMMY
+			ORDER BY T_DUMMY.RNUM            
+		
+	</select>
+
+	<select id="selectNormalDayCal" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+			SELECT  #{year}               YEAR
+			     ,  #{month}              MONTH
+				 ,  #{day}                DAY
+				 ,  #{week}                 WEEK
+				 ,  #{weeks}                WEEKS
+				 ,  #{maxWeeks}             MAX_WEEKS
+				 ,  #{lastDayMonth}         LAST_DAY_MONTH
+			     ,  (	SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE #{week} WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+			              FROM  COMTNRESTDE 
+			             WHERE  RESTDE = LPAD(#{year},4,'0')||LPAD(#{month},2,'0')||LPAD(#{day},2,'0')
+			               AND  RESTDE_SE_CODE IN ('01','02')                                   
+			        ) REST_AT
+			  FROM  DUAL      
+		
+	</select>
+	
+	<select id="selectNormalDayRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}     YEAR
+                 ,  #{month}    MONTH
+                 ,  #{day}      DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE 
+             WHERE  RESTDE         = LPAD(#{year},4,'0')||LPAD(#{month},2,'0')||LPAD(#{day},2,'0')
+               AND  RESTDE_SE_CODE   IN ('01','02')       
+		
+	</select>
+
+	<select id="selectNormalMonthRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}                YEAR
+                 ,  #{month}               MONTH
+                 ,  TO_CHAR(TO_NUMBER( SUBSTR(RESTDE,7,2))) DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE 
+             WHERE  RESTDE      LIKE LPAD(#{year},4,'0')||LPAD(#{month},2,'0')||'%'
+               AND  RESTDE_SE_CODE   IN ('01','02')       
+		
+	</select>
+
+	<select id="selectAdministDayCal" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+			SELECT  #{year}               YEAR
+			     ,  #{month}              MONTH
+				 ,  #{day}                DAY
+				 ,  #{week}                 WEEK
+				 ,  #{weeks}                WEEKS
+				 ,  #{maxWeeks}             MAX_WEEKS
+				 ,  #{lastDayMonth}         LAST_DAY_MONTH
+			     ,  (	SELECT  CASE (COUNT(*)) WHEN 0 THEN CASE #{week} WHEN 1 THEN 'Y' WHEN 7 THEN 'Y' ELSE 'N' END ELSE 'Y' END
+			              FROM  COMTNRESTDE 
+			             WHERE  RESTDE = LPAD(#{year},4,'0')||LPAD(#{month},2,'0')||LPAD(#{day},2,'0')
+			               AND  RESTDE_SE_CODE IN ('02','03')                                   
+			        ) REST_AT
+			  FROM  DUAL      
+		
+	</select>
+	
+	<select id="selectAdministDayRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}     YEAR
+                 ,  #{month}    MONTH
+                 ,  #{day}      DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE 
+             WHERE  RESTDE         = LPAD(#{year},4,'0')||LPAD(#{month},2,'0')||LPAD(#{day},2,'0')
+               AND  RESTDE_SE_CODE   IN ('02','03')       
+		
+	</select>
+
+	<select id="selectAdministMonthRestde" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovMap">
+		
+            SELECT  #{year}                YEAR
+                 ,  #{month}               MONTH
+                 ,  TO_CHAR(TO_NUMBER(SUBSTR(RESTDE,7,2))) DAY
+                 ,  RESTDE
+                 ,  RESTDE_NM
+              FROM  COMTNRESTDE 
+             WHERE  RESTDE      LIKE LPAD(#{year},4,'0')||LPAD(#{month},2,'0')||'%'
+               AND  RESTDE_SE_CODE   IN ('02','03')       
+		
+	</select>
+
+	<!-- 2024.10.29 권태성 휴일일자 검색 조건인 경우 searchKeyword를 formattedDtKeyword로 변경 -->
+	<select id="selectRestdeList" parameterType="egovframework.let.sym.cal.service.RestdeVO" resultType="egovMap">
+		
+			SELECT  * 
+			  FROM  (
+			SELECT ROWNUM RNUM, ALL_LIST.* 
+			  FROM  (
+			/* 구현 Sql */
+			SELECT  A.RESTDE_NO
+				 ,  A.RESTDE RESTDE_DE
+			     ,  A.RESTDE DBMS_KIND
+				 ,  A.RESTDE_NM
+				 ,  A.RESTDE_DC
+				 ,  B.CODE_NM        RESTDE_SE
+				 ,  A.RESTDE_SE_CODE
+			  FROM  COMTNRESTDE         A
+			     ,  COMTCCMMNDETAILCODE B
+			 WHERE  B.CODE_ID        = 'COM017'
+			   AND  A.RESTDE_SE_CODE = B.CODE
+		
+			<if test="searchCondition == 1">AND
+				A.RESTDE = #{formattedDtKeyword}
+			</if>
+			<if test="searchCondition == 2">AND
+				A.RESTDE_NM LIKE '%' || #{searchKeyword} || '%'
+			</if>
+		<![CDATA[
+			/* 구현 Sql */
+				    ) ALL_LIST
+				    )
+			 WHERE  RNUM  > #{firstIndex}
+			   AND  RNUM <= #{firstIndex} + #{recordCountPerPage}
+		]]>
+	</select>
+
+	<!-- 2024.10.29 권태성 휴일일자 검색 조건인 경우 searchKeyword를 formattedDtKeyword로 변경 -->
+	<select id="selectRestdeListTotCnt" parameterType="egovframework.let.sym.cal.service.RestdeVO" resultType="int">
+		
+			SELECT  COUNT(*) totcnt 
+			  FROM  COMTNRESTDE         A
+			     ,  COMTCCMMNDETAILCODE B
+			 WHERE  B.CODE_ID        = 'COM017'
+			   AND  A.RESTDE_SE_CODE = B.CODE
+		
+			<if test="searchCondition == 1">AND
+				RESTDE = #{formattedDtKeyword}
+			</if>
+			<if test="searchCondition == 2">AND
+				RESTDE_NM LIKE '%' || #{searchKeyword} || '%'
+			</if>
+	</select>
+
+	<insert id="insertRestde">
+		
+			INSERT 
+			  INTO  COMTNRESTDE
+			     (  RESTDE_NO
+				 ,  RESTDE
+				 ,  RESTDE_NM
+				 ,  RESTDE_DC
+				 ,  RESTDE_SE_CODE
+			     ,  FRST_REGIST_PNTTM
+			     ,  FRST_REGISTER_ID
+			     ,  LAST_UPDT_PNTTM
+			     ,  LAST_UPDUSR_ID
+			     ) 
+			VALUES
+			     (  #{restdeNo}
+				 ,  #{restdeDe}
+				 ,  #{restdeNm}
+				 ,  #{restdeDc}
+				 ,  #{restdeSeCode}
+			     ,  SYSDATE
+			     ,  #{frstRegisterId}
+			     ,  SYSDATE
+			     ,  #{frstRegisterId}
+			     ) 
+		
+	</insert>
+
+	<select id="selectRestdeDetail" parameterType="egovframework.let.sym.cal.service.Restde" resultType="egovframework.let.sym.cal.service.Restde">
+		
+			SELECT  A.RESTDE_NO      restdeNo
+			     ,  A.RESTDE      restdeDe
+				 ,  A.RESTDE_NM      restdeNm
+				 ,  A.RESTDE_DC      restdeDc
+				 ,  B.CODE_NM        restdeSe
+				 ,  A.RESTDE_SE_CODE restdeSeCode
+			  FROM  COMTNRESTDE         A
+			     ,  COMTCCMMNDETAILCODE B
+			 WHERE  B.CODE_ID        = 'COM017'
+			   AND  A.RESTDE_SE_CODE = B.CODE
+               AND  A.RESTDE_NO      = #{restdeNo}
+		
+	</select>
+
+	<update id="updateRestde">
+		
+            UPDATE  COMTNRESTDE 
+               SET  RESTDE_NM         = #{restdeNm}
+				 ,  RESTDE_DC         = #{restdeDc}
+				 ,  RESTDE_SE_CODE    = #{restdeSeCode}
+                 ,  LAST_UPDT_PNTTM = sysdate
+                 ,  LAST_UPDUSR_ID    = #{lastUpdusrId}
+             WHERE  RESTDE_NO         = #{restdeNo}
+		
+	</update>
+
+	<delete id="deleteRestde">
+		
+            DELETE  
+              FROM  COMTNRESTDE     
+             WHERE  RESTDE_NO = #{restdeNo}
+		
+	</delete>
+	
+</mapper>


### PR DESCRIPTION
## 변경 사유
sym/cal 모듈의 RestdeManageDAO가 EgovAbstractMapper 상속 방식으로 남아 있었으며, SQL mapper XML도 누락된 상태였음. eGovFrame 5.0에서 권장하는 @EgovMapper 인터페이스 방식으로 전환하여 일관성을 맞춤.

## 변경 내용
- `RestdeManageMapper` 인터페이스 신규 추가 (`@EgovMapper("restdeManageDao")`)
- `EgovCalRestdeManageServiceImpl`에서 `RestdeManageDAO` → `RestdeManageMapper` 주입으로 변경 (`@Resource(name="restdeManageDao")`)
- 누락된 SQL mapper XML 6종 신규 추가 (mysql/oracle/altibase/cubrid/tibero/hsql)
  - 공통컴포넌트(egovframe-common-components) SQL 기반으로 작성, parameterType 패키지를 `egovframework.let.sym.cal.service`로 조정

## 영향 범위
- `egovframework/let/sym/cal` 패키지만 변경
- 기존 동작 변화 없음 (SQL 동일, 메서드 시그니처 동일)

## 체크리스트
- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작 호환
- [x] SQL mapper XML namespace: `restdeManageDao` (인터페이스 bean name과 일치)
