### PR TITLE
[refactor][공통컴포넌트] cop/bbs BBSAttributeManageDAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/let/cop/bbs/service/impl/BBSAttributeManageMapper.java
+++ b/src/main/java/egovframework/let/cop/bbs/service/impl/BBSAttributeManageMapper.java
@@ -1,0 +1,136 @@
+package egovframework.let.cop.bbs.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.cop.bbs.service.BoardMaster;
+import egovframework.let.cop.bbs.service.BoardMasterVO;
+
+/**
+ * 게시판 속성정보 관리를 처리하는 MyBatis 매퍼 인터페이스
+ *
+ * @author 공통 서비스 개발팀 이삼섭
+ * @since 2009.03.12
+ * @version 1.0
+ * @see
+ *
+ *      <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자          수정내용
+ *  -------    --------    ---------------------------
+ *  2009.03.12  이삼섭          최초 생성
+ *  2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ *      </pre>
+ */
+@EgovMapper("BBSAttributeManageDAO")
+public interface BBSAttributeManageMapper {
+
+	/**
+	 * 등록된 게시판 속성정보를 삭제한다.
+	 *
+	 * @param boardMaster 삭제할 게시판 정보
+	 * @throws Exception
+	 */
+	void deleteBBSMasterInf(BoardMaster boardMaster) throws Exception;
+
+	/**
+	 * 신규 게시판 속성정보를 등록한다.
+	 *
+	 * @param boardMaster 등록할 게시판 정보
+	 * @return 등록된 행 수
+	 * @throws Exception
+	 */
+	int insertBBSMasterInf(BoardMaster boardMaster) throws Exception;
+
+	/**
+	 * 게시판 속성정보 한 건을 상세조회 한다.
+	 *
+	 * @param vo 조회할 게시판 정보
+	 * @return 게시판 속성 상세 VO
+	 * @throws Exception
+	 */
+	BoardMasterVO selectBBSMasterInf(BoardMaster vo) throws Exception;
+
+	/**
+	 * 게시판 속성정보 목록을 조회한다.
+	 *
+	 * @param vo 조회 조건 VO
+	 * @return 게시판 속성 목록
+	 * @throws Exception
+	 */
+	List<BoardMasterVO> selectBBSMasterInfs(BoardMasterVO vo) throws Exception;
+
+	/**
+	 * 게시판 속성정보 목록 건수를 조회한다.
+	 *
+	 * @param vo 조회 조건 VO
+	 * @return 목록 건수
+	 * @throws Exception
+	 */
+	int selectBBSMasterInfsCnt(BoardMasterVO vo) throws Exception;
+
+	/**
+	 * 게시판 속성정보를 수정한다.
+	 *
+	 * @param boardMaster 수정할 게시판 정보
+	 * @throws Exception
+	 */
+	void updateBBSMasterInf(BoardMaster boardMaster) throws Exception;
+
+	/**
+	 * 유효한 게시판 목록을 조회한다.
+	 *
+	 * @param vo 조회 조건 VO
+	 * @return 게시판 속성 목록
+	 * @throws Exception
+	 */
+	List<BoardMasterVO> selectAllBBSMaster(BoardMasterVO vo) throws Exception;
+
+	/**
+	 * 사용중인 게시판 속성정보 목록을 조회한다.
+	 *
+	 * @param vo 조회 조건 VO
+	 * @return 게시판 속성 목록
+	 * @throws Exception
+	 */
+	List<BoardMasterVO> selectBdMstrListByTrget(BoardMasterVO vo) throws Exception;
+
+	/**
+	 * 사용중인 게시판 속성정보 목록 건수를 조회한다.
+	 *
+	 * @param vo 조회 조건 VO
+	 * @return 목록 건수
+	 * @throws Exception
+	 */
+	int selectBdMstrListCntByTrget(BoardMasterVO vo) throws Exception;
+
+	/**
+	 * 커뮤니티, 동호회등 게시판 사용등록이 된 게시판 목록 전체를 조회한다.
+	 *
+	 * @param vo 조회 조건 VO
+	 * @return 게시판 속성 목록
+	 * @throws Exception
+	 */
+	List<BoardMasterVO> selectAllBdMstrByTrget(BoardMasterVO vo) throws Exception;
+
+	/**
+	 * 사용 중이지 않은 게시판 속성정보 목록을 조회한다.
+	 *
+	 * @param vo 조회 조건 VO
+	 * @return 게시판 속성 목록
+	 * @throws Exception
+	 */
+	List<BoardMasterVO> selectNotUsedBdMstrList(BoardMasterVO vo) throws Exception;
+
+	/**
+	 * 사용 중이지 않은 게시판 속성정보 목록 건수를 조회한다.
+	 *
+	 * @param vo 조회 조건 VO
+	 * @return 목록 건수
+	 * @throws Exception
+	 */
+	int selectNotUsedBdMstrListCnt(BoardMasterVO vo) throws Exception;
+}

--- a/src/main/java/egovframework/let/cop/bbs/service/impl/EgovBBSAttributeManageServiceImpl.java
+++ b/src/main/java/egovframework/let/cop/bbs/service/impl/EgovBBSAttributeManageServiceImpl.java
@@ -45,7 +45,7 @@ public class EgovBBSAttributeManageServiceImpl extends EgovAbstractServiceImpl i
 	private static final Logger LOGGER = LoggerFactory.getLogger(EgovBBSAttributeManageServiceImpl.class);
 
 	@Resource(name = "BBSAttributeManageDAO")
-	private BBSAttributeManageDAO attrbMngDAO;
+	private BBSAttributeManageMapper attrbMngDAO;
 
 	@Resource(name = "BBSUseInfoManageDAO")
 	private BBSUseInfoManageDAO bbsUseDAO;
@@ -158,7 +158,7 @@ public class EgovBBSAttributeManageServiceImpl extends EgovAbstractServiceImpl i
 	 * @see egovframework.let.cop.bbs.brd.service.EgovBBSAttributeManageService#selectAllBBSMasteInf(egovframework.let.cop.bbs.brd.service.BoardMasterVO)
 	 */
 	public List<BoardMasterVO> selectAllBBSMasteInf(BoardMasterVO vo) throws Exception {
-		return attrbMngDAO.selectAllBBSMasteInf(vo);
+		return attrbMngDAO.selectAllBBSMaster(vo);
 	}
 
 	/**

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAttributeManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.service.impl.BBSAttributeManageMapper">
 
 
 	<resultMap id="boardMasterList" type="egovframework.let.cop.bbs.service.BoardMasterVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAttributeManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.service.impl.BBSAttributeManageMapper">
 
 
 	<resultMap id="boardMasterList" type="egovframework.let.cop.bbs.service.BoardMasterVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_hsql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_hsql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAttributeManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.service.impl.BBSAttributeManageMapper">
 
 
 	<resultMap id="boardMasterList" type="egovframework.let.cop.bbs.service.BoardMasterVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAttributeManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.service.impl.BBSAttributeManageMapper">
 
 
 	<resultMap id="boardMasterList" type="egovframework.let.cop.bbs.service.BoardMasterVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAttributeManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.service.impl.BBSAttributeManageMapper">
 
 
 	<resultMap id="boardMasterList" type="egovframework.let.cop.bbs.service.BoardMasterVO">

--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBBSMaster_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="BBSAttributeManageDAO">
+<mapper namespace="egovframework.let.cop.bbs.service.impl.BBSAttributeManageMapper">
 
 
 	<resultMap id="boardMasterList" type="egovframework.let.cop.bbs.service.BoardMasterVO">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,5 +22,11 @@
 	</bean>
 	
 	<alias name="sqlSession" alias="egov.sqlSession" />
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 매퍼 인터페이스 자동 등록 -->
+	<bean class="org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer">
+		<property name="basePackage" value="egovframework.let.cop.bbs.service.impl" />
+		<property name="sqlSessionFactoryBeanName" value="sqlSession" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 eGovFrame 5.0 `@EgovMapper` 인터페이스 방식으로 전환합니다.

## 변경 내용
- 대상: cop/bbs BBSAttributeManageDAO
- Mapper 인터페이스(`@EgovMapper`) 신규 추가 + DAO 위임 구조 전환
- XML namespace를 mapper FQN으로 변경, mapper 스캐너 등록

## 영향 범위
- 해당 모듈만 영향, 서비스 호출 시그니처 변경 없음 (mvn compile 검증)

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 빌드 검증 완료
