### PR TITLE
[refactor][공통컴포넌트] cop/bbs·com 4개 DAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/let/cop/bbs/service/impl/BBSManageDAO.java
+++ b/src/main/java/egovframework/let/cop/bbs/service/impl/BBSManageDAO.java
@@ -1,8 +1,10 @@
 package egovframework.let.cop.bbs.service.impl;
+
 import java.util.Iterator;
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.cop.bbs.service.Board;
@@ -26,7 +28,10 @@ import egovframework.let.cop.bbs.service.BoardVO;
  *  </pre>
  */
 @Repository("BBSManageDAO")
-public class BBSManageDAO extends EgovAbstractMapper {
+public class BBSManageDAO {
+
+    @Resource(name = "BBSManageDAO")
+    private BBSManageMapper bbsManageMapper;
 
     /**
      * 게시판에 게시물을 등록 한다.
@@ -35,10 +40,9 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void insertBoardArticle(Board board) throws Exception {
-    	long nttId = (Long)selectOne("BBSManageDAO.selectMaxNttId");
-    	board.setNttId(nttId);
-
-    	insert("BBSManageDAO.insertBoardArticle", board);
+        long nttId = bbsManageMapper.selectMaxNttId();
+        board.setNttId(nttId);
+        bbsManageMapper.insertBoardArticle(board);
     }
 
     /**
@@ -48,24 +52,23 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public long replyBoardArticle(Board board) throws Exception {
-		long nttId = (Long)selectOne("BBSManageDAO.selectMaxNttId");
-		board.setNttId(nttId);
-	
-		insert("BBSManageDAO.replyBoardArticle", board);
-	
-		//----------------------------------------------------------
-		// 현재 글 이후 게시물에 대한 NTT_NO를 증가 (정렬을 추가하기 위해)
-		//----------------------------------------------------------
-		//String parentId = board.getParnts();
-		long nttNo = (Long)selectOne("BBSManageDAO.getParentNttNo", board);
-	
-		board.setNttNo(nttNo);
-		update("BBSManageDAO.updateOtherNttNo", board);
-	
-		board.setNttNo(nttNo + 1);
-		update("BBSManageDAO.updateNttNo", board);
-	
-		return nttId;
+        long nttId = bbsManageMapper.selectMaxNttId();
+        board.setNttId(nttId);
+
+        bbsManageMapper.replyBoardArticle(board);
+
+        //----------------------------------------------------------
+        // 현재 글 이후 게시물에 대한 NTT_NO를 증가 (정렬을 추가하기 위해)
+        //----------------------------------------------------------
+        long nttNo = bbsManageMapper.getParentNttNo(board);
+
+        board.setNttNo(nttNo);
+        bbsManageMapper.updateOtherNttNo(board);
+
+        board.setNttNo(nttNo + 1);
+        bbsManageMapper.updateNttNo(board);
+
+        return nttId;
     }
 
     /**
@@ -76,7 +79,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public BoardVO selectBoardArticle(BoardVO boardVO) throws Exception {
-    	return (BoardVO)selectOne("BBSManageDAO.selectBoardArticle", boardVO);
+        return bbsManageMapper.selectBoardArticle(boardVO);
     }
 
     /**
@@ -87,7 +90,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<BoardVO> selectBoardArticleList(BoardVO boardVO) throws Exception {
-    	return selectList("BBSManageDAO.selectBoardArticleList", boardVO);
+        return bbsManageMapper.selectBoardArticleList(boardVO);
     }
 
     /**
@@ -98,7 +101,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectBoardArticleListCnt(BoardVO boardVO) throws Exception {
-    	return (Integer)selectOne("BBSManageDAO.selectBoardArticleListCnt", boardVO);
+        return bbsManageMapper.selectBoardArticleListCnt(boardVO);
     }
 
     /**
@@ -108,7 +111,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void updateBoardArticle(Board board) throws Exception {
-    	update("BBSManageDAO.updateBoardArticle", board);
+        bbsManageMapper.updateBoardArticle(board);
     }
 
     /**
@@ -118,17 +121,17 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void deleteBoardArticle(Board board) throws Exception {
-    	update("BBSManageDAO.deleteBoardArticle", board);
+        bbsManageMapper.deleteBoardArticle(board);
     }
 
     /**
      * 게시물에 대한 조회 건수를 수정 한다.
      *
-     * @param board
+     * @param boardVO
      * @throws Exception
      */
     public void updateInqireCo(BoardVO boardVO) throws Exception {
-    	update("BBSManageDAO.updateInqireCo", boardVO);
+        bbsManageMapper.updateInqireCo(boardVO);
     }
 
     /**
@@ -139,18 +142,18 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectMaxInqireCo(BoardVO boardVO) throws Exception {
-    	return (Integer)selectOne("BBSManageDAO.selectMaxInqireCo", boardVO);
+        return bbsManageMapper.selectMaxInqireCo(boardVO);
     }
 
     /**
      * 게시판에 대한 목록을 정렬 순서로 조회 한다.
      *
-     * @param boardVO
+     * @param board
      * @return
      * @throws Exception
      */
     public List<BoardVO> selectNoticeListForSort(Board board) throws Exception {
-    	return selectList("BBSManageDAO.selectNoticeListForSort", board);
+        return bbsManageMapper.selectNoticeListForSort(board);
     }
 
     /**
@@ -160,23 +163,23 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void updateSortOrder(List<BoardVO> sortList) throws Exception {
-    	BoardVO vo;
-    	Iterator<BoardVO> iter = sortList.iterator();
-    	while (iter.hasNext()) {
-    		vo = iter.next();
-    		update("BBSManageDAO.updateSortOrder", vo);
-    	}
+        BoardVO vo;
+        Iterator<BoardVO> iter = sortList.iterator();
+        while (iter.hasNext()) {
+            vo = iter.next();
+            bbsManageMapper.updateSortOrder(vo);
+        }
     }
 
     /**
      * 게시판에 대한 현재 게시물 번호의 최대값을 구한다.
      *
-     * @param boardVO
+     * @param board
      * @return
      * @throws Exception
      */
     public long selectNoticeItemForSort(Board board) throws Exception {
-    	return (Long)selectOne("BBSManageDAO.selectNoticeItemForSort", board);
+        return bbsManageMapper.selectNoticeItemForSort(board);
     }
 
     /**
@@ -187,7 +190,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<BoardVO> selectGuestList(BoardVO boardVO) throws Exception {
-    	return selectList("BBSManageDAO.selectGuestList", boardVO);
+        return bbsManageMapper.selectGuestList(boardVO);
     }
 
     /**
@@ -198,7 +201,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectGuestListCnt(BoardVO boardVO) throws Exception {
-    	return (Integer)selectOne("BBSManageDAO.selectGuestListCnt", boardVO);
+        return bbsManageMapper.selectGuestListCnt(boardVO);
     }
 
     /**
@@ -208,7 +211,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void deleteGuestList(BoardVO boardVO) throws Exception {
-    	update("BBSManageDAO.deleteGuestList", boardVO);
+        bbsManageMapper.deleteGuestList(boardVO);
     }
 
     /**
@@ -219,6 +222,7 @@ public class BBSManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public String getPasswordInf(Board board) throws Exception {
-    	return (String)selectOne("BBSManageDAO.getPasswordInf", board);
+        return bbsManageMapper.getPasswordInf(board);
     }
+
 }

--- a/src/main/java/egovframework/let/cop/bbs/service/impl/BBSManageMapper.java
+++ b/src/main/java/egovframework/let/cop/bbs/service/impl/BBSManageMapper.java
@@ -1,0 +1,180 @@
+package egovframework.let.cop.bbs.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.cop.bbs.service.Board;
+import egovframework.let.cop.bbs.service.BoardVO;
+
+/**
+ * 게시물 관리를 위한 MyBatis 매퍼 인터페이스
+ * @author 공통 서비스 개발팀 이삼섭
+ * @since 2009.03.19
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자          수정내용
+ *  -------    --------    ---------------------------
+ *  2009.03.19  이삼섭          최초 생성
+ *  2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ *  </pre>
+ */
+@EgovMapper("BBSManageDAO")
+public interface BBSManageMapper {
+
+	/**
+	 * 게시판에 게시물 번호 최대값을 조회한다.
+	 * @return long
+	 * @throws Exception
+	 */
+	long selectMaxNttId() throws Exception;
+
+	/**
+	 * 게시판에 게시물을 등록한다.
+	 * @param board 게시물 정보
+	 * @throws Exception
+	 */
+	void insertBoardArticle(Board board) throws Exception;
+
+	/**
+	 * 게시판에 답변 게시물을 등록한다.
+	 * @param board 게시물 정보
+	 * @throws Exception
+	 */
+	void replyBoardArticle(Board board) throws Exception;
+
+	/**
+	 * 게시물 한 건에 대한 상세 내용을 조회한다.
+	 * @param boardVO 게시물 조회 조건
+	 * @return BoardVO
+	 * @throws Exception
+	 */
+	BoardVO selectBoardArticle(BoardVO boardVO) throws Exception;
+
+	/**
+	 * 조건에 맞는 게시물 목록을 조회한다.
+	 * @param boardVO 게시물 조회 조건
+	 * @return List
+	 * @throws Exception
+	 */
+	List<BoardVO> selectBoardArticleList(BoardVO boardVO) throws Exception;
+
+	/**
+	 * 조건에 맞는 게시물 목록에 대한 전체 건수를 조회한다.
+	 * @param boardVO 게시물 조회 조건
+	 * @return int
+	 * @throws Exception
+	 */
+	int selectBoardArticleListCnt(BoardVO boardVO) throws Exception;
+
+	/**
+	 * 게시물 한 건의 내용을 수정한다.
+	 * @param board 게시물 정보
+	 * @throws Exception
+	 */
+	void updateBoardArticle(Board board) throws Exception;
+
+	/**
+	 * 게시물 한 건을 삭제한다.
+	 * @param board 게시물 정보
+	 * @throws Exception
+	 */
+	void deleteBoardArticle(Board board) throws Exception;
+
+	/**
+	 * 게시물에 대한 조회 건수를 수정한다.
+	 * @param boardVO 게시물 정보
+	 * @throws Exception
+	 */
+	void updateInqireCo(BoardVO boardVO) throws Exception;
+
+	/**
+	 * 게시물에 대한 현재 조회 건수를 조회한다.
+	 * @param boardVO 게시물 조회 조건
+	 * @return int
+	 * @throws Exception
+	 */
+	int selectMaxInqireCo(BoardVO boardVO) throws Exception;
+
+	/**
+	 * 게시판에 대한 목록을 정렬 순서로 조회한다.
+	 * @param board 게시물 정보
+	 * @return List
+	 * @throws Exception
+	 */
+	List<BoardVO> selectNoticeListForSort(Board board) throws Exception;
+
+	/**
+	 * 게시판에 대한 정렬 순서를 수정한다.
+	 * @param vo 게시물 정보
+	 * @throws Exception
+	 */
+	void updateSortOrder(BoardVO vo) throws Exception;
+
+	/**
+	 * 게시판에 대한 현재 게시물 번호의 최대값을 구한다.
+	 * @param board 게시물 정보
+	 * @return long
+	 * @throws Exception
+	 */
+	long selectNoticeItemForSort(Board board) throws Exception;
+
+	/**
+	 * 방명록에 대한 목록을 조회한다.
+	 * @param boardVO 게시물 조회 조건
+	 * @return List
+	 * @throws Exception
+	 */
+	List<BoardVO> selectGuestList(BoardVO boardVO) throws Exception;
+
+	/**
+	 * 방명록에 대한 목록 건수를 조회한다.
+	 * @param boardVO 게시물 조회 조건
+	 * @return int
+	 * @throws Exception
+	 */
+	int selectGuestListCnt(BoardVO boardVO) throws Exception;
+
+	/**
+	 * 방명록 내용을 삭제한다.
+	 * @param boardVO 게시물 정보
+	 * @throws Exception
+	 */
+	void deleteGuestList(BoardVO boardVO) throws Exception;
+
+	/**
+	 * 방명록에 대한 패스워드를 조회한다.
+	 * @param board 게시물 정보
+	 * @return String
+	 * @throws Exception
+	 */
+	String getPasswordInf(Board board) throws Exception;
+
+	/**
+	 * 답변 글의 부모 NTT_NO를 조회한다.
+	 * @param board 게시물 정보
+	 * @return long
+	 * @throws Exception
+	 */
+	long getParentNttNo(Board board) throws Exception;
+
+	/**
+	 * 현재 글 이후 게시물의 NTT_NO를 증가시킨다.
+	 * @param board 게시물 정보
+	 * @throws Exception
+	 */
+	void updateOtherNttNo(Board board) throws Exception;
+
+	/**
+	 * 게시물의 NTT_NO를 수정한다.
+	 * @param board 게시물 정보
+	 * @throws Exception
+	 */
+	void updateNttNo(Board board) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/cop/com/service/impl/BBSUseInfoManageDAO.java
+++ b/src/main/java/egovframework/let/cop/com/service/impl/BBSUseInfoManageDAO.java
@@ -2,7 +2,8 @@ package egovframework.let.cop.com.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.cop.com.service.BoardUseInf;
@@ -26,7 +27,10 @@ import egovframework.let.cop.com.service.BoardUseInfVO;
  * </pre>
  */
 @Repository("BBSUseInfoManageDAO")
-public class BBSUseInfoManageDAO extends EgovAbstractMapper {
+public class BBSUseInfoManageDAO {
+
+    @Resource(name = "BBSUseInfoManageDAO")
+    private BBSUseInfoManageMapper bbsUseInfoManageMapper;
 
     /**
      * 게시판 사용 정보를 삭제한다.
@@ -35,47 +39,47 @@ public class BBSUseInfoManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void deleteBBSUseInf(BoardUseInf bdUseInf) throws Exception {
-    	update("BBSUseInfoManageDAO.deleteBBSUseInf", bdUseInf);
+        bbsUseInfoManageMapper.deleteBBSUseInf(bdUseInf);
     }
 
     /**
      * 커뮤니티에 사용되는 게시판 사용정보 목록을 조회한다.
      *
-     * @param bdUseInf
+     * @param bdUseVO
      * @throws Exception
      */
     public List<BoardUseInf> selectBBSUseInfByCmmnty(BoardUseInfVO bdUseVO) throws Exception {
-    	return selectList("BBSUseInfoManageDAO.selectBBSUseInfByCmmnty", bdUseVO);
+        return bbsUseInfoManageMapper.selectBBSUseInfByCmmnty(bdUseVO);
     }
 
     /**
      * 동호회에 사용되는 게시판 사용정보 목록을 조회한다.
      *
-     * @param bdUseInf
+     * @param bdUseVO
      * @throws Exception
      */
     public List<BoardUseInf> selectBBSUseInfByClub(BoardUseInfVO bdUseVO) throws Exception {
-    	return selectList("BBSUseInfoManageDAO.selectBBSUseInfByClub", bdUseVO);
+        return bbsUseInfoManageMapper.selectBBSUseInfByClub(bdUseVO);
     }
 
     /**
      * 커뮤니티에 사용되는 모든 게시판 사용정보를 삭제한다.
      *
-     * @param bdUseInf
+     * @param bdUseVO
      * @throws Exception
      */
     public void deleteAllBBSUseInfByCmmnty(BoardUseInfVO bdUseVO) throws Exception {
-    	update("BBSUseInfoManageDAO.deleteAllBBSUseInfByCmmnty", bdUseVO);
+        bbsUseInfoManageMapper.deleteAllBBSUseInfByCmmnty(bdUseVO);
     }
 
     /**
      * 동호회에 사용되는 모든 게시판 사용정보를 삭제한다.
      *
-     * @param bdUseInf
+     * @param bdUseVO
      * @throws Exception
      */
     public void deleteAllBBSUseInfByClub(BoardUseInfVO bdUseVO) throws Exception {
-    	update("BBSUseInfoManageDAO.deleteAllBBSUseInfByClub", bdUseVO);
+        bbsUseInfoManageMapper.deleteAllBBSUseInfByClub(bdUseVO);
     }
 
     /**
@@ -85,7 +89,7 @@ public class BBSUseInfoManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void insertBBSUseInf(BoardUseInf bdUseInf) throws Exception {
-    	insert("BBSUseInfoManageDAO.insertBBSUseInf", bdUseInf);
+        bbsUseInfoManageMapper.insertBBSUseInf(bdUseInf);
     }
 
     /**
@@ -96,17 +100,18 @@ public class BBSUseInfoManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<BoardUseInfVO> selectBBSUseInfs(BoardUseInfVO bdUseVO) throws Exception {
-    	return selectList("BBSUseInfoManageDAO.selectBBSUseInfs", bdUseVO);
+        return bbsUseInfoManageMapper.selectBBSUseInfs(bdUseVO);
     }
 
     /**
+     * 게시판 사용정보 목록 전체 건수를 조회한다.
      *
      * @param bdUseVO
      * @return
      * @throws Exception
      */
     public int selectBBSUseInfsCnt(BoardUseInfVO bdUseVO) throws Exception {
-    	return (Integer)selectOne("BBSUseInfoManageDAO.selectBBSUseInfsCnt", bdUseVO);
+        return bbsUseInfoManageMapper.selectBBSUseInfsCnt(bdUseVO);
     }
 
     /**
@@ -117,7 +122,7 @@ public class BBSUseInfoManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public BoardUseInfVO selectBBSUseInf(BoardUseInfVO bdUseVO) throws Exception {
-    	return (BoardUseInfVO)selectOne("BBSUseInfoManageDAO.selectBBSUseInf", bdUseVO);
+        return bbsUseInfoManageMapper.selectBBSUseInf(bdUseVO);
     }
 
     /**
@@ -127,7 +132,7 @@ public class BBSUseInfoManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void updateBBSUseInf(BoardUseInf bdUseInf) throws Exception {
-    	update("BBSUseInfoManageDAO.updateBBSUseInf", bdUseInf);
+        bbsUseInfoManageMapper.updateBBSUseInf(bdUseInf);
     }
 
     /**
@@ -137,7 +142,7 @@ public class BBSUseInfoManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void deleteBBSUseInfByBoardId(BoardUseInf bdUseInf) throws Exception {
-    	update("BBSUseInfoManageDAO.deleteBBSUseInfByBoardId", bdUseInf);
+        bbsUseInfoManageMapper.deleteBBSUseInfByBoardId(bdUseInf);
     }
 
     /**
@@ -148,7 +153,7 @@ public class BBSUseInfoManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<BoardUseInfVO> selectBBSUseInfsByTrget(BoardUseInfVO bdUseVO) throws Exception {
-    	return selectList("BBSUseInfoManageDAO.selectBBSUseInfsByTrget", bdUseVO);
+        return bbsUseInfoManageMapper.selectBBSUseInfsByTrget(bdUseVO);
     }
 
     /**
@@ -159,7 +164,7 @@ public class BBSUseInfoManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectBBSUseInfsCntByTrget(BoardUseInfVO bdUseVO) throws Exception {
-    	return (Integer)selectOne("BBSUseInfoManageDAO.selectBBSUseInfsCntByTrget", bdUseVO);
+        return bbsUseInfoManageMapper.selectBBSUseInfsCntByTrget(bdUseVO);
     }
 
     /**
@@ -169,6 +174,7 @@ public class BBSUseInfoManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void updateBBSUseInfByTrget(BoardUseInf bdUseInf) throws Exception {
-    	update("BBSUseInfoManageDAO.updateBBSUseInfByTrget", bdUseInf);
+        bbsUseInfoManageMapper.updateBBSUseInfByTrget(bdUseInf);
     }
+
 }

--- a/src/main/java/egovframework/let/cop/com/service/impl/BBSUseInfoManageMapper.java
+++ b/src/main/java/egovframework/let/cop/com/service/impl/BBSUseInfoManageMapper.java
@@ -1,0 +1,135 @@
+package egovframework.let.cop.com.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.cop.com.service.BoardUseInf;
+import egovframework.let.cop.com.service.BoardUseInfVO;
+
+/**
+ * 게시판 이용정보를 관리하기 위한 MyBatis 매퍼 인터페이스
+ * @author 공통서비스개발팀 이삼섭
+ * @since 2009.04.02
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일       수정자           수정내용
+ *  -------     --------    ---------------------------
+ *   2009.04.02  이삼섭          최초 생성
+ *   2011.05.31  JJY           경량환경 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper("BBSUseInfoManageDAO")
+public interface BBSUseInfoManageMapper {
+
+	/**
+	 * 게시판 사용 정보를 삭제한다.
+	 * @param bdUseInf 게시판 사용 정보
+	 * @throws Exception
+	 */
+	void deleteBBSUseInf(BoardUseInf bdUseInf) throws Exception;
+
+	/**
+	 * 커뮤니티에 사용되는 게시판 사용정보 목록을 조회한다.
+	 * @param bdUseVO 게시판 사용정보 조회 조건
+	 * @return List
+	 * @throws Exception
+	 */
+	List<BoardUseInf> selectBBSUseInfByCmmnty(BoardUseInfVO bdUseVO) throws Exception;
+
+	/**
+	 * 동호회에 사용되는 게시판 사용정보 목록을 조회한다.
+	 * @param bdUseVO 게시판 사용정보 조회 조건
+	 * @return List
+	 * @throws Exception
+	 */
+	List<BoardUseInf> selectBBSUseInfByClub(BoardUseInfVO bdUseVO) throws Exception;
+
+	/**
+	 * 커뮤니티에 사용되는 모든 게시판 사용정보를 삭제한다.
+	 * @param bdUseVO 게시판 사용정보 조회 조건
+	 * @throws Exception
+	 */
+	void deleteAllBBSUseInfByCmmnty(BoardUseInfVO bdUseVO) throws Exception;
+
+	/**
+	 * 동호회에 사용되는 모든 게시판 사용정보를 삭제한다.
+	 * @param bdUseVO 게시판 사용정보 조회 조건
+	 * @throws Exception
+	 */
+	void deleteAllBBSUseInfByClub(BoardUseInfVO bdUseVO) throws Exception;
+
+	/**
+	 * 게시판 사용정보를 등록한다.
+	 * @param bdUseInf 게시판 사용 정보
+	 * @throws Exception
+	 */
+	void insertBBSUseInf(BoardUseInf bdUseInf) throws Exception;
+
+	/**
+	 * 게시판 사용정보 목록을 조회한다.
+	 * @param bdUseVO 게시판 사용정보 조회 조건
+	 * @return List
+	 * @throws Exception
+	 */
+	List<BoardUseInfVO> selectBBSUseInfs(BoardUseInfVO bdUseVO) throws Exception;
+
+	/**
+	 * 게시판 사용정보 목록 전체 건수를 조회한다.
+	 * @param bdUseVO 게시판 사용정보 조회 조건
+	 * @return int
+	 * @throws Exception
+	 */
+	int selectBBSUseInfsCnt(BoardUseInfVO bdUseVO) throws Exception;
+
+	/**
+	 * 게시판 사용정보에 대한 상세정보를 조회한다.
+	 * @param bdUseVO 게시판 사용정보 조회 조건
+	 * @return BoardUseInfVO
+	 * @throws Exception
+	 */
+	BoardUseInfVO selectBBSUseInf(BoardUseInfVO bdUseVO) throws Exception;
+
+	/**
+	 * 게시판 사용정보를 수정한다.
+	 * @param bdUseInf 게시판 사용 정보
+	 * @throws Exception
+	 */
+	void updateBBSUseInf(BoardUseInf bdUseInf) throws Exception;
+
+	/**
+	 * 게시판에 대한 사용정보를 삭제한다.
+	 * @param bdUseInf 게시판 사용 정보
+	 * @throws Exception
+	 */
+	void deleteBBSUseInfByBoardId(BoardUseInf bdUseInf) throws Exception;
+
+	/**
+	 * 커뮤니티, 동호회에 사용되는 게시판 사용정보에 대한 목록을 조회한다.
+	 * @param bdUseVO 게시판 사용정보 조회 조건
+	 * @return List
+	 * @throws Exception
+	 */
+	List<BoardUseInfVO> selectBBSUseInfsByTrget(BoardUseInfVO bdUseVO) throws Exception;
+
+	/**
+	 * 커뮤니티, 동호회에 사용되는 게시판 사용정보에 대한 전체 건수를 조회한다.
+	 * @param bdUseVO 게시판 사용정보 조회 조건
+	 * @return int
+	 * @throws Exception
+	 */
+	int selectBBSUseInfsCntByTrget(BoardUseInfVO bdUseVO) throws Exception;
+
+	/**
+	 * 커뮤니티, 동호회에 사용되는 게시판 사용정보를 수정한다.
+	 * @param bdUseInf 게시판 사용 정보
+	 * @throws Exception
+	 */
+	void updateBBSUseInfByTrget(BoardUseInf bdUseInf) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/cop/com/service/impl/EgovUserInfManageDAO.java
+++ b/src/main/java/egovframework/let/cop/com/service/impl/EgovUserInfManageDAO.java
@@ -2,7 +2,8 @@ package egovframework.let.cop.com.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.cop.com.service.UserInfVO;
@@ -25,7 +26,10 @@ import egovframework.let.cop.com.service.UserInfVO;
  * </pre>
  */
 @Repository("EgovUserInfManageDAO")
-public class EgovUserInfManageDAO extends EgovAbstractMapper {
+public class EgovUserInfManageDAO {
+
+    @Resource(name = "EgovUserInfManageDAO")
+    private EgovUserInfManageMapper egovUserInfManageMapper;
 
     /**
      * 사용자 정보에 대한 목록을 조회한다.
@@ -35,7 +39,7 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<UserInfVO> selectUserList(UserInfVO userVO) throws Exception {
-    	return selectList("EgovUserInfManageDAO.selectUserList", userVO);
+        return egovUserInfManageMapper.selectUserList(userVO);
     }
 
     /**
@@ -46,7 +50,7 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectUserListCnt(UserInfVO userVO) throws Exception {
-    	return (Integer)selectOne("EgovUserInfManageDAO.selectUserListCnt", userVO);
+        return egovUserInfManageMapper.selectUserListCnt(userVO);
     }
 
     /**
@@ -57,7 +61,7 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<UserInfVO> selectCmmntyUserList(UserInfVO userVO) throws Exception {
-    	return selectList("EgovUserInfManageDAO.selectCmmntyUserList", userVO);
+        return egovUserInfManageMapper.selectCmmntyUserList(userVO);
     }
 
     /**
@@ -68,7 +72,7 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectCmmntyUserListCnt(UserInfVO userVO) throws Exception {
-    	return (Integer)selectOne("EgovUserInfManageDAO.selectCmmntyUserListCnt", userVO);
+        return egovUserInfManageMapper.selectCmmntyUserListCnt(userVO);
     }
 
     /**
@@ -79,7 +83,7 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<UserInfVO> selectCmmntyMngrList(UserInfVO userVO) throws Exception {
-    	return selectList("EgovUserInfManageDAO.selectCmmntyMngrList", userVO);
+        return egovUserInfManageMapper.selectCmmntyMngrList(userVO);
     }
 
     /**
@@ -90,7 +94,7 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectCmmntyMngrListCnt(UserInfVO userVO) throws Exception {
-    	return (Integer)selectOne("EgovUserInfManageDAO.selectCmmntyMngrListCnt", userVO);
+        return egovUserInfManageMapper.selectCmmntyMngrListCnt(userVO);
     }
 
     /**
@@ -101,7 +105,7 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<UserInfVO> selectClubUserList(UserInfVO userVO) throws Exception {
-    	return selectList("EgovUserInfManageDAO.selectClubUserList", userVO);
+        return egovUserInfManageMapper.selectClubUserList(userVO);
     }
 
     /**
@@ -112,7 +116,7 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectClubUserListCnt(UserInfVO userVO) throws Exception {
-    	return (Integer)selectOne("EgovUserInfManageDAO.selectClubUserListCnt", userVO);
+        return egovUserInfManageMapper.selectClubUserListCnt(userVO);
     }
 
     /**
@@ -123,7 +127,7 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<UserInfVO> selectClubOprtrList(UserInfVO userVO) throws Exception {
-    	return selectList("EgovUserInfManageDAO.selectClubOprtrList", userVO);
+        return egovUserInfManageMapper.selectClubOprtrList(userVO);
     }
 
     /**
@@ -134,7 +138,7 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectClubOprtrListCnt(UserInfVO userVO) throws Exception {
-    	return (Integer)selectOne("EgovUserInfManageDAO.selectClubOprtrListCnt", userVO);
+        return egovUserInfManageMapper.selectClubOprtrListCnt(userVO);
     }
 
     /**
@@ -145,7 +149,7 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<UserInfVO> selectAllClubUser(UserInfVO userVO) throws Exception {
-    	return selectList("EgovUserInfManageDAO.selectAllClubUser", userVO);
+        return egovUserInfManageMapper.selectAllClubUser(userVO);
     }
 
     /**
@@ -156,6 +160,7 @@ public class EgovUserInfManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<UserInfVO> selectAllCmmntyUser(UserInfVO userVO) throws Exception {
-    	return selectList("EgovUserInfManageDAO.selectAllCmmntyUser", userVO);
+        return egovUserInfManageMapper.selectAllCmmntyUser(userVO);
     }
+
 }

--- a/src/main/java/egovframework/let/cop/com/service/impl/EgovUserInfManageMapper.java
+++ b/src/main/java/egovframework/let/cop/com/service/impl/EgovUserInfManageMapper.java
@@ -1,0 +1,125 @@
+package egovframework.let.cop.com.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.cop.com.service.UserInfVO;
+
+/**
+ * 협업 활용 사용자 정보 조회를 위한 MyBatis 매퍼 인터페이스
+ * @author 공통서비스개발팀 이삼섭
+ * @since 2009.04.06
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.06  이삼섭          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper("EgovUserInfManageDAO")
+public interface EgovUserInfManageMapper {
+
+	/**
+	 * 사용자 정보에 대한 목록을 조회한다.
+	 * @param userVO 사용자 조회 조건
+	 * @return List
+	 * @throws Exception
+	 */
+	List<UserInfVO> selectUserList(UserInfVO userVO) throws Exception;
+
+	/**
+	 * 사용자 정보에 대한 목록 전체 건수를 조회한다.
+	 * @param userVO 사용자 조회 조건
+	 * @return int
+	 * @throws Exception
+	 */
+	int selectUserListCnt(UserInfVO userVO) throws Exception;
+
+	/**
+	 * 커뮤니티 사용자 목록을 조회한다.
+	 * @param userVO 사용자 조회 조건
+	 * @return List
+	 * @throws Exception
+	 */
+	List<UserInfVO> selectCmmntyUserList(UserInfVO userVO) throws Exception;
+
+	/**
+	 * 커뮤니티 사용자 목록에 대한 전체 건수를 조회한다.
+	 * @param userVO 사용자 조회 조건
+	 * @return int
+	 * @throws Exception
+	 */
+	int selectCmmntyUserListCnt(UserInfVO userVO) throws Exception;
+
+	/**
+	 * 커뮤니티 관리자 목록을 조회한다.
+	 * @param userVO 사용자 조회 조건
+	 * @return List
+	 * @throws Exception
+	 */
+	List<UserInfVO> selectCmmntyMngrList(UserInfVO userVO) throws Exception;
+
+	/**
+	 * 커뮤니티 관리자 목록에 대한 전체 건수를 조회한다.
+	 * @param userVO 사용자 조회 조건
+	 * @return int
+	 * @throws Exception
+	 */
+	int selectCmmntyMngrListCnt(UserInfVO userVO) throws Exception;
+
+	/**
+	 * 동호회 사용자 목록을 조회한다.
+	 * @param userVO 사용자 조회 조건
+	 * @return List
+	 * @throws Exception
+	 */
+	List<UserInfVO> selectClubUserList(UserInfVO userVO) throws Exception;
+
+	/**
+	 * 동호회 사용자 목록에 대한 전체 건수를 조회한다.
+	 * @param userVO 사용자 조회 조건
+	 * @return int
+	 * @throws Exception
+	 */
+	int selectClubUserListCnt(UserInfVO userVO) throws Exception;
+
+	/**
+	 * 동호회 운영자 목록을 조회한다.
+	 * @param userVO 사용자 조회 조건
+	 * @return List
+	 * @throws Exception
+	 */
+	List<UserInfVO> selectClubOprtrList(UserInfVO userVO) throws Exception;
+
+	/**
+	 * 동호회 운영자 목록에 대한 전체 건수를 조회한다.
+	 * @param userVO 사용자 조회 조건
+	 * @return int
+	 * @throws Exception
+	 */
+	int selectClubOprtrListCnt(UserInfVO userVO) throws Exception;
+
+	/**
+	 * 동호회에 대한 모든 사용자 목록을 조회한다.
+	 * @param userVO 사용자 조회 조건
+	 * @return List
+	 * @throws Exception
+	 */
+	List<UserInfVO> selectAllClubUser(UserInfVO userVO) throws Exception;
+
+	/**
+	 * 커뮤니티에 대한 모든 사용자 목록을 조회한다.
+	 * @param userVO 사용자 조회 조건
+	 * @return List
+	 * @throws Exception
+	 */
+	List<UserInfVO> selectAllCmmntyUser(UserInfVO userVO) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/cop/com/service/impl/TemplateManageDAO.java
+++ b/src/main/java/egovframework/let/cop/com/service/impl/TemplateManageDAO.java
@@ -1,7 +1,9 @@
 package egovframework.let.cop.com.service.impl;
+
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
+import jakarta.annotation.Resource;
+
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.cop.com.service.TemplateInf;
@@ -25,7 +27,10 @@ import egovframework.let.cop.com.service.TemplateInfVO;
  * </pre>
  */
 @Repository("TemplateManageDAO")
-public class TemplateManageDAO extends EgovAbstractMapper {
+public class TemplateManageDAO {
+
+    @Resource(name = "TemplateManageDAO")
+    private TemplateManageMapper templateManageMapper;
 
     /**
      * 템플릿 정보를 삭제한다.
@@ -34,7 +39,7 @@ public class TemplateManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void deleteTemplateInf(TemplateInf tmplatInf) throws Exception {
-    	update("TemplateManageDAO.deleteTemplateInf", tmplatInf);
+        templateManageMapper.deleteTemplateInf(tmplatInf);
     }
 
     /**
@@ -44,7 +49,7 @@ public class TemplateManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void insertTemplateInf(TemplateInf tmplatInf) throws Exception {
-    	insert("TemplateManageDAO.insertTemplateInf", tmplatInf);
+        templateManageMapper.insertTemplateInf(tmplatInf);
     }
 
     /**
@@ -54,7 +59,7 @@ public class TemplateManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public void updateTemplateInf(TemplateInf tmplatInf) throws Exception {
-    	update("TemplateManageDAO.updateTemplateInf", tmplatInf);
+        templateManageMapper.updateTemplateInf(tmplatInf);
     }
 
     /**
@@ -65,7 +70,7 @@ public class TemplateManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<TemplateInfVO> selectTemplateInfs(TemplateInfVO tmplatInfVO) throws Exception {
-    	return selectList("TemplateManageDAO.selectTemplateInfs", tmplatInfVO);
+        return templateManageMapper.selectTemplateInfs(tmplatInfVO);
     }
 
     /**
@@ -76,7 +81,7 @@ public class TemplateManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public int selectTemplateInfsCnt(TemplateInfVO tmplatInfVO) throws Exception {
-    	return (Integer)selectOne("TemplateManageDAO.selectTemplateInfsCnt", tmplatInfVO);
+        return templateManageMapper.selectTemplateInfsCnt(tmplatInfVO);
     }
 
     /**
@@ -87,8 +92,7 @@ public class TemplateManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public TemplateInfVO selectTemplateInf(TemplateInfVO tmplatInfVO) throws Exception {
-    	return (TemplateInfVO)selectOne("TemplateManageDAO.selectTemplateInf", tmplatInfVO);
-
+        return templateManageMapper.selectTemplateInf(tmplatInfVO);
     }
 
     /**
@@ -99,7 +103,7 @@ public class TemplateManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public TemplateInfVO selectTemplatePreview(TemplateInfVO tmplatInfVO) throws Exception {
-    	return null;
+        return null;
     }
 
     /**
@@ -110,7 +114,7 @@ public class TemplateManageDAO extends EgovAbstractMapper {
      * @throws Exception
      */
     public List<TemplateInfVO> selectTemplateInfsByCode(TemplateInfVO tmplatInfVO) throws Exception {
-    	return selectList("TemplateManageDAO.selectTemplateInfsByCode", tmplatInfVO);
+        return templateManageMapper.selectTemplateInfsByCode(tmplatInfVO);
     }
 
 }

--- a/src/main/java/egovframework/let/cop/com/service/impl/TemplateManageMapper.java
+++ b/src/main/java/egovframework/let/cop/com/service/impl/TemplateManageMapper.java
@@ -1,0 +1,83 @@
+package egovframework.let.cop.com.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.cop.com.service.TemplateInf;
+import egovframework.let.cop.com.service.TemplateInfVO;
+
+/**
+ * 템플릿 정보관리를 위한 MyBatis 매퍼 인터페이스
+ * @author 공통서비스개발팀 이삼섭
+ * @since 2009.03.17
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.17  이삼섭          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper("TemplateManageDAO")
+public interface TemplateManageMapper {
+
+	/**
+	 * 템플릿 정보를 삭제한다.
+	 * @param tmplatInf 템플릿 정보
+	 * @throws Exception
+	 */
+	void deleteTemplateInf(TemplateInf tmplatInf) throws Exception;
+
+	/**
+	 * 템플릿 정보를 등록한다.
+	 * @param tmplatInf 템플릿 정보
+	 * @throws Exception
+	 */
+	void insertTemplateInf(TemplateInf tmplatInf) throws Exception;
+
+	/**
+	 * 템플릿 정보를 수정한다.
+	 * @param tmplatInf 템플릿 정보
+	 * @throws Exception
+	 */
+	void updateTemplateInf(TemplateInf tmplatInf) throws Exception;
+
+	/**
+	 * 템플릿에 대한 목록을 조회한다.
+	 * @param tmplatInfVO 템플릿 조회 조건
+	 * @return List
+	 * @throws Exception
+	 */
+	List<TemplateInfVO> selectTemplateInfs(TemplateInfVO tmplatInfVO) throws Exception;
+
+	/**
+	 * 템플릿에 대한 목록 전체 건수를 조회한다.
+	 * @param tmplatInfVO 템플릿 조회 조건
+	 * @return int
+	 * @throws Exception
+	 */
+	int selectTemplateInfsCnt(TemplateInfVO tmplatInfVO) throws Exception;
+
+	/**
+	 * 템플릿에 대한 상세정보를 조회한다.
+	 * @param tmplatInfVO 템플릿 조회 조건
+	 * @return TemplateInfVO
+	 * @throws Exception
+	 */
+	TemplateInfVO selectTemplateInf(TemplateInfVO tmplatInfVO) throws Exception;
+
+	/**
+	 * 템플릿 구분에 따른 목록을 조회한다.
+	 * @param tmplatInfVO 템플릿 조회 조건
+	 * @return List
+	 * @throws Exception
+	 */
+	List<TemplateInfVO> selectTemplateInfsByCode(TemplateInfVO tmplatInfVO) throws Exception;
+
+}

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,5 +22,16 @@
 	</bean>
 	
 	<alias name="sqlSession" alias="egov.sqlSession" />
-	
+
+	<!-- @EgovMapper 어노테이션이 붙은 매퍼 인터페이스 자동 등록 -->
+	<bean class="org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer">
+		<property name="basePackage" value="egovframework.let.cop.bbs.service.impl" />
+		<property name="sqlSessionFactoryBeanName" value="sqlSession" />
+	</bean>
+
+	<bean class="org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer">
+		<property name="basePackage" value="egovframework.let.cop.com.service.impl" />
+		<property name="sqlSessionFactoryBeanName" value="sqlSession" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 eGovFrame 5.0 `@EgovMapper` 인터페이스 방식으로 전환합니다.

## 변경 내용
- 대상: cop/bbs·cop/com 4개 DAO(BBSManage·BBSUseInfoManage·EgovUserInfManage·TemplateManage)
- Mapper 인터페이스(`@EgovMapper`) 신규 추가 + DAO 위임 구조 전환
- XML namespace를 mapper FQN으로 변경, mapper 스캐너 등록

## 영향 범위
- 해당 모듈만 영향, 서비스 호출 시그니처 변경 없음 (mvn compile 검증)

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 빌드 검증 완료
