### PR TITLE
[test][main] EgovStringUtil·EgovNumberUtil·EgovDateUtil 단위 테스트 추가

### DIFF
--- a/src/test/java/egovframework/let/utl/fcc/service/EgovDateUtilTest.java
+++ b/src/test/java/egovframework/let/utl/fcc/service/EgovDateUtilTest.java
@@ -1,0 +1,147 @@
+package egovframework.let.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovDateUtil 단위 테스트
+ *
+ * @author 이백행
+ * @since 2024-09-21
+ */
+class EgovDateUtilTest {
+
+    @Test
+    @DisplayName("addYearMonthDay: 날짜에 연월일을 가감한다")
+    void testAddYearMonthDay() {
+        assertEquals("19810916", EgovDateUtil.addYearMonthDay("19810828", 0, 0, 19));
+        assertEquals("20060218", EgovDateUtil.addYearMonthDay("20060228", 0, 0, -10));
+        assertEquals("20060310", EgovDateUtil.addYearMonthDay("20060228", 0, 0, 10));
+        assertEquals("20050228", EgovDateUtil.addYearMonthDay("20050331", 0, -1, 0));
+        assertEquals("20060301", EgovDateUtil.addYearMonthDay("20040229", 2, 0, 1));
+    }
+
+    @Test
+    @DisplayName("addYear: 연도를 가감한다")
+    void testAddYear() {
+        assertEquals("20620201", EgovDateUtil.addYear("20000201", 62));
+        assertEquals("20000201", EgovDateUtil.addYear("20620201", -62));
+        assertEquals("20060228", EgovDateUtil.addYear("20040229", 2));
+    }
+
+    @Test
+    @DisplayName("addMonth: 월을 가감한다")
+    void testAddMonth() {
+        assertEquals("20020201", EgovDateUtil.addMonth("20010201", 12));
+        assertEquals("20050228", EgovDateUtil.addMonth("20040229", 12));
+        assertEquals("20060228", EgovDateUtil.addMonth("20060131", 1));
+    }
+
+    @Test
+    @DisplayName("addDay: 일을 가감한다")
+    void testAddDay() {
+        assertEquals("20000201", EgovDateUtil.addDay("19991201", 62));
+        assertEquals("19991201", EgovDateUtil.addDay("20000201", -62));
+        assertEquals("20050903", EgovDateUtil.addDay("20050831", 3));
+    }
+
+    @Test
+    @DisplayName("getDaysDiff: 두 날짜 사이의 일 수 차이를 반환한다")
+    void testGetDaysDiff() {
+        assertEquals(10, EgovDateUtil.getDaysDiff("20060228", "20060310"));
+        assertEquals(365, EgovDateUtil.getDaysDiff("20060101", "20070101"));
+        assertEquals(-28, EgovDateUtil.getDaysDiff("19990228", "19990131"));
+        assertEquals(0, EgovDateUtil.getDaysDiff("20060801", "20060801"));
+    }
+
+    @Test
+    @DisplayName("checkDate: 유효한 날짜이면 true를 반환한다")
+    void testCheckDate() {
+        assertTrue(EgovDateUtil.checkDate("20060228"));
+        assertTrue(EgovDateUtil.checkDate("2006-02-28"));
+        assertFalse(EgovDateUtil.checkDate("1999-02-35"));
+        assertFalse(EgovDateUtil.checkDate("2000-13-31"));
+        assertFalse(EgovDateUtil.checkDate("2006-11-31"));
+    }
+
+    @Test
+    @DisplayName("formatDate: yyyyMMdd(8자리) 날짜 문자열을 지정 구분자로 포맷한다")
+    void testFormatDate() {
+        assertEquals("2003.04.05", EgovDateUtil.formatDate("20030405", "."));
+        assertEquals("2004/01/01", EgovDateUtil.formatDate("20040101", "/"));
+    }
+
+    @Test
+    @DisplayName("formatDate: 월이 00이면 연도만 반환한다")
+    void testFormatDateMonthZero() {
+        assertEquals("2003", EgovDateUtil.formatDate("20030000", "."));
+    }
+
+    @Test
+    @DisplayName("validChkTime: 콜론 포함 5자리(HH:MM)를 4자리(HHMM)로 정규화한다")
+    void testValidChkTime() {
+        assertEquals("1512", EgovDateUtil.validChkTime("15:12"));
+        assertEquals("0905", EgovDateUtil.validChkTime("0905"));
+    }
+
+    @Test
+    @DisplayName("validChkDate: null이거나 길이가 8/10이 아니면 예외가 발생한다")
+    void testValidChkDateException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovDateUtil.validChkDate(null));
+        // 길이가 7인 경우 예외
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovDateUtil.validChkDate("2006228"));
+    }
+
+    @Test
+    @DisplayName("validChkDate: yyyy-MM-dd 형식이면 하이픈을 제거하고 반환한다")
+    void testValidChkDate() {
+        assertEquals("20060228", EgovDateUtil.validChkDate("2006-02-28"));
+        assertEquals("20060228", EgovDateUtil.validChkDate("20060228"));
+    }
+
+    @Test
+    @DisplayName("getToday: 오늘 날짜를 yyyyMMdd 형식으로 반환한다")
+    void testGetToday() {
+        String today = EgovDateUtil.getToday();
+        assertNotNull(today);
+        assertEquals(8, today.length());
+        assertTrue(today.matches("\\d{8}"));
+    }
+
+    @Test
+    @DisplayName("convertWeek: 영문 요일명을 국문으로 변환한다")
+    void testConvertWeek() {
+        assertEquals("일요일", EgovDateUtil.convertWeek("SUN"));
+        assertEquals("월요일", EgovDateUtil.convertWeek("MON"));
+        assertEquals("화요일", EgovDateUtil.convertWeek("TUE"));
+        assertEquals("수요일", EgovDateUtil.convertWeek("WED"));
+        assertEquals("목요일", EgovDateUtil.convertWeek("THR"));
+        assertEquals("금요일", EgovDateUtil.convertWeek("FRI"));
+        assertEquals("토요일", EgovDateUtil.convertWeek("SAT"));
+    }
+
+    @Test
+    @DisplayName("getRandomDate: 반환된 날짜가 시작일자와 종료일자 사이에 있다")
+    void testGetRandomDate() {
+        String result = EgovDateUtil.getRandomDate("20200101", "20201231");
+        assertNotNull(result);
+        assertEquals(8, result.length());
+        assertTrue(result.compareTo("20200101") >= 0);
+        assertTrue(result.compareTo("20201231") <= 0);
+    }
+
+    @Test
+    @DisplayName("getRandomDate: 종료일자가 시작일자보다 이전이면 예외가 발생한다")
+    void testGetRandomDateInvalidRange() {
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovDateUtil.getRandomDate("20201231", "20200101"));
+    }
+}

--- a/src/test/java/egovframework/let/utl/fcc/service/EgovNumberUtilTest.java
+++ b/src/test/java/egovframework/let/utl/fcc/service/EgovNumberUtilTest.java
@@ -1,0 +1,86 @@
+package egovframework.let.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovNumberUtil 단위 테스트
+ *
+ * @author 이백행
+ * @since 2024-09-21
+ */
+class EgovNumberUtilTest {
+
+    @Test
+    @DisplayName("getRandomNum: 반환값이 시작숫자와 종료숫자 사이에 있다")
+    void testGetRandomNumRange() {
+        for (int i = 0; i < 50; i++) {
+            int result = EgovNumberUtil.getRandomNum(1, 10);
+            assertTrue(result >= 1 && result <= 10,
+                    "범위 초과: " + result);
+        }
+    }
+
+    @Test
+    @DisplayName("getNumSearchCheck: 숫자집합에 검색숫자가 포함되면 true를 반환한다")
+    void testGetNumSearchCheck() {
+        assertTrue(EgovNumberUtil.getNumSearchCheck(12345678, 7));
+        assertFalse(EgovNumberUtil.getNumSearchCheck(12345678, 9));
+        assertTrue(EgovNumberUtil.getNumSearchCheck(100, 1));
+    }
+
+    @Test
+    @DisplayName("getNumToStrCnvr: 숫자를 문자열로 변환한다")
+    void testGetNumToStrCnvr() {
+        assertEquals("20081212", EgovNumberUtil.getNumToStrCnvr(20081212));
+        assertEquals("0", EgovNumberUtil.getNumToStrCnvr(0));
+        assertEquals("-1", EgovNumberUtil.getNumToStrCnvr(-1));
+    }
+
+    @Test
+    @DisplayName("getNumToDateCnvr: 8자리 숫자를 yyyy-MM-dd 형식으로 변환한다")
+    void testGetNumToDateCnvr8Digits() {
+        assertEquals("2008-12-12", EgovNumberUtil.getNumToDateCnvr(20081212));
+        assertEquals("2000-01-01", EgovNumberUtil.getNumToDateCnvr(20000101));
+    }
+
+    @Test
+    @DisplayName("getNumToDateCnvr: 8자리 또는 14자리가 아니면 예외가 발생한다")
+    void testGetNumToDateCnvrInvalidLength() {
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovNumberUtil.getNumToDateCnvr(2008121));
+        assertThrows(IllegalArgumentException.class,
+                () -> EgovNumberUtil.getNumToDateCnvr(123456789));
+    }
+
+    @Test
+    @DisplayName("getNumberValidCheck: 숫자로만 구성된 문자열이면 true를 반환한다")
+    void testGetNumberValidCheck() {
+        assertTrue(EgovNumberUtil.getNumberValidCheck("12345"));
+        assertFalse(EgovNumberUtil.getNumberValidCheck("123a5"));
+        assertFalse(EgovNumberUtil.getNumberValidCheck("123 5"));
+        assertTrue(EgovNumberUtil.getNumberValidCheck("0"));
+    }
+
+    @Test
+    @DisplayName("getNumberCnvr: 숫자집합 내 특정 숫자를 다른 숫자로 치환한다")
+    void testGetNumberCnvr() {
+        assertEquals(99945678, EgovNumberUtil.getNumberCnvr(12345678, 123, 999));
+        assertEquals(200, EgovNumberUtil.getNumberCnvr(100, 1, 2));
+    }
+
+    @Test
+    @DisplayName("checkRlnoInteger: 음수이면 -1, 정수이면 0, 실수이면 1을 반환한다")
+    void testCheckRlnoInteger() {
+        assertEquals(-1, EgovNumberUtil.checkRlnoInteger(-5.0));
+        // double 10.0은 String.valueOf 시 "10.0"이 되어 소수점이 포함됨 → 실수(1) 반환
+        assertEquals(1, EgovNumberUtil.checkRlnoInteger(10.0));
+        // 정수(0) 판정을 받으려면 소수점 없는 표현이 필요하나 double 타입 특성상 해당 없음
+        assertEquals(-1, EgovNumberUtil.checkRlnoInteger(-0.1));
+    }
+}

--- a/src/test/java/egovframework/let/utl/fcc/service/EgovStringUtilTest.java
+++ b/src/test/java/egovframework/let/utl/fcc/service/EgovStringUtilTest.java
@@ -1,0 +1,170 @@
+package egovframework.let.utl.fcc.service;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EgovStringUtil 단위 테스트
+ *
+ * @author 이백행
+ * @since 2024-09-21
+ */
+class EgovStringUtilTest {
+
+    @Test
+    @DisplayName("isEmpty: null 또는 빈 문자열이면 true를 반환한다")
+    void testIsEmpty() {
+        assertTrue(EgovStringUtil.isEmpty(null));
+        assertTrue(EgovStringUtil.isEmpty(""));
+        assertFalse(EgovStringUtil.isEmpty(" "));
+        assertFalse(EgovStringUtil.isEmpty("abc"));
+    }
+
+    @Test
+    @DisplayName("cutString: 지정 길이 초과 시 잘라낸 후 suffix를 붙인다")
+    void testCutStringWithSuffix() {
+        assertEquals("Hel...", EgovStringUtil.cutString("Hello World", "...", 3));
+        assertEquals("Hi", EgovStringUtil.cutString("Hi", "...", 5));
+        assertNull(EgovStringUtil.cutString(null, "...", 3));
+    }
+
+    @Test
+    @DisplayName("cutString: 지정 길이 초과 시 잘라낸다")
+    void testCutStringNoSuffix() {
+        assertEquals("Hel", EgovStringUtil.cutString("Hello", 3));
+        assertEquals("Hi", EgovStringUtil.cutString("Hi", 5));
+        assertNull(EgovStringUtil.cutString(null, 3));
+    }
+
+    @Test
+    @DisplayName("remove: 특정 문자를 모두 제거한다")
+    void testRemove() {
+        assertEquals("qeed", EgovStringUtil.remove("queued", 'u'));
+        assertEquals("queued", EgovStringUtil.remove("queued", 'z'));
+        assertNull(EgovStringUtil.remove(null, 'u'));
+        assertEquals("", EgovStringUtil.remove("", 'u'));
+    }
+
+    @Test
+    @DisplayName("removeCommaChar: 콤마를 모두 제거한다")
+    void testRemoveCommaChar() {
+        assertEquals("asdfgqweqe", EgovStringUtil.removeCommaChar("asdfg,qweqe"));
+        assertNull(EgovStringUtil.removeCommaChar(null));
+        assertEquals("", EgovStringUtil.removeCommaChar(""));
+    }
+
+    @Test
+    @DisplayName("removeMinusChar: 마이너스를 모두 제거한다")
+    void testRemoveMinusChar() {
+        assertEquals("asdfgqweqe", EgovStringUtil.removeMinusChar("a-sdfg-qweqe"));
+        assertNull(EgovStringUtil.removeMinusChar(null));
+    }
+
+    @Test
+    @DisplayName("replace: 모든 대상 문자열을 치환한다")
+    void testReplace() {
+        assertEquals("bcbc", EgovStringUtil.replace("aaaa", "aa", "bc"));
+        assertEquals("hello world", EgovStringUtil.replace("hello java", "java", "world"));
+    }
+
+    @Test
+    @DisplayName("replaceOnce: 첫 번째 대상 문자열만 치환한다")
+    void testReplaceOnce() {
+        assertEquals("Xbab", EgovStringUtil.replaceOnce("abab", "a", "X"));
+        assertEquals("noop", EgovStringUtil.replaceOnce("noop", "z", "X"));
+    }
+
+    @Test
+    @DisplayName("indexOf: 검색 대상 위치를 반환하며 null이면 -1을 반환한다")
+    void testIndexOf() {
+        assertEquals(2, EgovStringUtil.indexOf("aabaabaa", "b"));
+        assertEquals(0, EgovStringUtil.indexOf("aabaabaa", "a"));
+        assertEquals(-1, EgovStringUtil.indexOf(null, "a"));
+        assertEquals(-1, EgovStringUtil.indexOf("abc", null));
+    }
+
+    @Test
+    @DisplayName("lowerCase: 소문자로 변환한다")
+    void testLowerCase() {
+        assertEquals("abc", EgovStringUtil.lowerCase("aBc"));
+        assertEquals("", EgovStringUtil.lowerCase(""));
+        assertNull(EgovStringUtil.lowerCase(null));
+    }
+
+    @Test
+    @DisplayName("upperCase: 대문자로 변환한다")
+    void testUpperCase() {
+        assertEquals("ABC", EgovStringUtil.upperCase("aBc"));
+        assertEquals("", EgovStringUtil.upperCase(""));
+        assertNull(EgovStringUtil.upperCase(null));
+    }
+
+    @Test
+    @DisplayName("removeWhitespace: 모든 공백을 제거한다")
+    void testRemoveWhitespace() {
+        assertEquals("abc", EgovStringUtil.removeWhitespace("   ab  c  "));
+        assertEquals("abc", EgovStringUtil.removeWhitespace("abc"));
+        assertNull(EgovStringUtil.removeWhitespace(null));
+        assertEquals("", EgovStringUtil.removeWhitespace(""));
+    }
+
+    @Test
+    @DisplayName("split: 구분자로 문자열을 배열로 분리한다")
+    void testSplit() {
+        assertArrayEquals(new String[]{"a", "b", "c"}, EgovStringUtil.split("a,b,c", ","));
+        assertArrayEquals(new String[]{"hello"}, EgovStringUtil.split("hello", ","));
+    }
+
+    @Test
+    @DisplayName("stripStart: 앞쪽 지정 문자를 제거한다")
+    void testStripStart() {
+        assertEquals("abc  ", EgovStringUtil.stripStart("yxabc  ", "xyz"));
+        assertEquals("abc", EgovStringUtil.stripStart("  abc", null));
+        assertNull(EgovStringUtil.stripStart(null, null));
+    }
+
+    @Test
+    @DisplayName("stripEnd: 뒤쪽 지정 문자를 제거한다")
+    void testStripEnd() {
+        assertEquals("  abc", EgovStringUtil.stripEnd("  abcyx", "xyz"));
+        assertEquals("abc", EgovStringUtil.stripEnd("abc  ", null));
+        assertNull(EgovStringUtil.stripEnd(null, null));
+    }
+
+    @Test
+    @DisplayName("addMinusChar: 8자리 날짜에 하이픈을 추가한다")
+    void testAddMinusChar() {
+        assertEquals("2010-09-01", EgovStringUtil.addMinusChar("20100901"));
+        assertEquals("", EgovStringUtil.addMinusChar("2010090"));
+    }
+
+    @Test
+    @DisplayName("decode: 두 문자열이 같으면 returnStr, 다르면 defaultStr을 반환한다")
+    void testDecode4Args() {
+        assertEquals("foo", EgovStringUtil.decode(null, null, "foo", "bar"));
+        assertEquals("bar", EgovStringUtil.decode("", null, "foo", "bar"));
+        assertEquals("foo", EgovStringUtil.decode("하이", "하이", "foo", "bar"));
+        assertEquals("bar", EgovStringUtil.decode("하이", "하이  ", "foo", "bar"));
+    }
+
+    @Test
+    @DisplayName("isNullToString: null이면 빈 문자열을 반환한다")
+    void testIsNullToString() {
+        assertEquals("", EgovStringUtil.isNullToString(null));
+        assertEquals("hello", EgovStringUtil.isNullToString("  hello  "));
+    }
+
+    @Test
+    @DisplayName("nullConvert(Object): null 또는 'null' 문자열이면 빈 문자열을 반환한다")
+    void testNullConvertObject() {
+        assertEquals("", EgovStringUtil.nullConvert((Object) null));
+        assertEquals("", EgovStringUtil.nullConvert((Object) "null"));
+        assertEquals("hello", EgovStringUtil.nullConvert((Object) "  hello  "));
+    }
+}


### PR DESCRIPTION
## 변경 사유

`egovframework/let/utl/fcc/service` 패키지의 핵심 유틸리티 클래스들이 테스트 없이 사용되고 있어 회귀 검증 수단이 없었다. 외부 의존성(DB, Spring 컨텍스트) 없이 실행 가능한 단위 테스트를 추가하여 메서드 단위 동작을 문서화하고 향후 변경 시 안전망을 제공한다.

## 변경 내용

- `EgovStringUtilTest`: isEmpty, cutString, remove, removeCommaChar, removeMinusChar, replace, replaceOnce, indexOf, lowerCase, upperCase, removeWhitespace, split, stripStart, stripEnd, addMinusChar, decode, isNullToString, nullConvert 등 19개 테스트
- `EgovNumberUtilTest`: getRandomNum 범위 검증, getNumSearchCheck, getNumToStrCnvr, getNumToDateCnvr(유효/비유효), getNumberValidCheck, getNumberCnvr, checkRlnoInteger 등 8개 테스트
- `EgovDateUtilTest`: addYearMonthDay, addYear, addMonth, addDay, getDaysDiff, checkDate, formatDate, validChkDate/validChkTime, getToday, convertWeek, getRandomDate 등 15개 테스트

## 영향 범위

테스트 코드만 추가. 운영 코드 변경 없음.

## 확인 사항

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 기존 동작에 영향 없음
- [ ] 42개 테스트 모두 통과 확인 (JUnit Platform Console Standalone으로 로컬 검증)
