### PR TITLE
fix: HSQL 임베디드 DB 시드 스크립트 인코딩 명시(UTF-8)

### DIFF
--- a/src/main/resources/egovframework/spring/com/context-datasource.xml
+++ b/src/main/resources/egovframework/spring/com/context-datasource.xml
@@ -18,7 +18,7 @@
     
     <!-- hsql -->
     <jdbc:embedded-database id="dataSource-hsql" type="HSQL">
-		<jdbc:script location="classpath:/db/shtdb.sql"/>
+		<jdbc:script location="classpath:/db/shtdb.sql" encoding="UTF-8"/>
     </jdbc:embedded-database>
 	
     <!-- <bean id="dataSource-hsql" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">


### PR DESCRIPTION
## 문제

`context-datasource.xml`의 임베디드 HSQL 데이터소스가 시드 스크립트(`shtdb.sql`)를 읽을 때 인코딩을 지정하지 않습니다.

```xml
<jdbc:embedded-database id="dataSource-hsql" type="HSQL">
    <jdbc:script location="classpath:/db/shtdb.sql"/>
</jdbc:embedded-database>
```

Spring의 `jdbc:script`는 `encoding` 속성이 없으면 JVM의 기본 charset(`Charset.defaultCharset()`)으로 파일을 읽습니다. `shtdb.sql`은 UTF-8로 저장되어 있는데, 한국어 로케일 Windows 환경처럼 JVM 기본 charset이 MS949로 결정되는 환경에서는 이 파일을 MS949로 잘못 디코딩하면서 게시판명("공지사항" 등) 같은 한글 시드 데이터가 깨진 채로 임베디드 DB에 적재됩니다.

## 검증

로컬(macOS)에서는 JDK가 기본 charset을 UTF-8로 고정해 재현되지 않아, 실제 문제가 되는 디코딩 단계를 직접 재현했습니다. `shtdb.sql`의 원본 UTF-8 바이트를 MS949로 디코딩하면:

```
UTF-8로 디코딩 : 공지사항
MS949로 디코딩 : 怨듭??궗?빆   (전형적인 UTF-8→MS949 오디코딩 mojibake)
```

수정 후에는 `encoding="UTF-8"`이 명시되어 플랫폼 기본값과 무관하게 항상 올바르게 디코딩됩니다. 수정된 컨텍스트로 임베디드 DB를 직접 기동해 `LETTNBBSMASTER.BBS_NM` 값이 "공지사항"으로 정상 적재되는 것도 확인했습니다.

## 변경 사항

- `src/main/resources/egovframework/spring/com/context-datasource.xml`: `jdbc:script`에 `encoding="UTF-8"` 추가 (1줄)

## 체크리스트

- [x] 단일 주제만 다룸(다른 변경 없음)
- [x] 기존 동작에 영향 없음(UTF-8 기본 환경에서는 완전히 동일하게 동작, 비-UTF-8 기본 환경에서만 문제를 해결)
- [x] `mvn package` 빌드 통과 확인
- [x] 별도 하네스로 Spring 컨텍스트를 직접 기동해 시드 데이터 정상 적재 확인