### PR TITLE
refactor(datasource): 커넥션 풀을 HikariCP로 전환

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
 		<log4j2.version>2.25.3</log4j2.version>
 		<slf4j.version>2.0.17</slf4j.version>
 		<commons-beanutils.version>1.11.0</commons-beanutils.version>
+		<hikaricp.version>6.3.3</hikaricp.version>
 		<protobuf.java.version>3.25.5</protobuf.java.version>
 		<parsson.version>1.1.7</parsson.version>
 	</properties>
@@ -169,8 +170,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-dbcp2</artifactId>
+			<groupId>com.zaxxer</groupId>
+			<artifactId>HikariCP</artifactId>
+			<version>${hikaricp.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>

--- a/src/main/resources/egovframework/spring/com/context-datasource.xml
+++ b/src/main/resources/egovframework/spring/com/context-datasource.xml
@@ -21,50 +21,56 @@
 		<jdbc:script location="classpath:/db/shtdb.sql"/>
     </jdbc:embedded-database>
 	
-    <!-- <bean id="dataSource-hsql" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+    <!-- <bean id="dataSource-hsql" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
 		<property name="driverClassName" value="net.sf.log4jdbc.DriverSpy"/>
-		<property name="url" value="jdbc:log4jdbc:hsqldb:hsql://localhost/sampledb"/>
+		<property name="jdbcUrl" value="jdbc:log4jdbc:hsqldb:hsql://localhost/sampledb"/>
 		<property name="username" value="sa"/>
+		<property name="maximumPoolSize" value="10"/>
     </bean> -->
 
     <!-- mysql -->
-    <bean id="dataSource-mysql" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+    <bean id="dataSource-mysql" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
         <property name="driverClassName" value="${Globals.DriverClassName}"/>
-        <property name="url" value="${Globals.Url}" />
+        <property name="jdbcUrl" value="${Globals.Url}" />
         <property name="username" value="${Globals.UserName}"/>
         <property name="password" value="${Globals.Password}"/>
+        <property name="maximumPoolSize" value="10"/>
     </bean>
     
     <!-- Oracle -->
-    <bean id="dataSource-oracle" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+    <bean id="dataSource-oracle" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
         <property name="driverClassName" value="${Globals.DriverClassName}"/>
-        <property name="url" value="${Globals.Url}" />
+        <property name="jdbcUrl" value="${Globals.Url}" />
         <property name="username" value="${Globals.UserName}"/>
         <property name="password" value="${Globals.Password}"/>
+        <property name="maximumPoolSize" value="10"/>
     </bean>
     
     <!-- Altibase -->
-    <bean id="dataSource-altibase" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+    <bean id="dataSource-altibase" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
         <property name="driverClassName" value="${Globals.DriverClassName}"/>
-        <property name="url" value="${Globals.Url}" />
+        <property name="jdbcUrl" value="${Globals.Url}" />
         <property name="username" value="${Globals.UserName}"/>
         <property name="password" value="${Globals.Password}"/>
+        <property name="maximumPoolSize" value="10"/>
     </bean>
 
     <!-- Tibero -->
-    <bean id="dataSource-tibero" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+    <bean id="dataSource-tibero" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
         <property name="driverClassName" value="${Globals.DriverClassName}"/>
-        <property name="url" value="${Globals.Url}" />
+        <property name="jdbcUrl" value="${Globals.Url}" />
         <property name="username" value="${Globals.UserName}"/>
         <property name="password" value="${Globals.Password}"/>
+        <property name="maximumPoolSize" value="10"/>
     </bean>
     
     <!-- cubrid -->
-    <bean id="dataSource-cubrid" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+    <bean id="dataSource-cubrid" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
         <property name="driverClassName" value="${Globals.DriverClassName}"/>
-        <property name="url" value="${Globals.Url}" />
+        <property name="jdbcUrl" value="${Globals.Url}" />
         <property name="username" value="${Globals.UserName}"/>
         <property name="password" value="${Globals.Password}"/>
+        <property name="maximumPoolSize" value="10"/>
     </bean>
     
 </beans>


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

Apache Commons DBCP2 기반 데이터소스를 HikariCP로 전환하여 커넥션 풀 구성을 개선합니다.

## 수정된 소스 내용 Modified source

- `commons-dbcp2` 의존성을 제거했습니다.
- `HikariCP 6.3.3` 의존성을 추가했습니다.
- MySQL, Oracle, Altibase, Tibero, Cubrid 데이터소스 구현체를 `HikariDataSource`로 변경했습니다.
- 주석 처리된 HSQL 데이터소스 예제도 HikariCP 설정으로 변경했습니다.
- HikariCP 규격에 맞게 `url` 속성을 `jdbcUrl`로 변경했습니다.
- 각 데이터소스의 `maximumPoolSize`를 `10`으로 설정했습니다.
- 빈 종료 시 HikariCP 리소스가 정리되도록 `destroy-method="close"`를 유지했습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

프로젝트의 Surefire 설정에 `skipTests=true`가 지정되어 있어 JUnit 테스트는 실행되지 않았습니다.

다음 항목을 검증했습니다.

- 지정된 JDK 17.0.17 및 Maven 3.9.9 환경에서 `mvn package` 성공
- 의존성 트리에서 `com.zaxxer:HikariCP:6.3.3` 확인
- 의존성 트리에서 `commons-dbcp2`가 제거된 것을 확인
- 생성된 WAR의 `WEB-INF/lib/HikariCP-6.3.3.jar` 포함 확인
- Spring 데이터소스 XML 구문 검사 통과
- `git diff --check` 통과

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

http://localhost:8080/egovframe-template-simple

https://youtu.be/9WNc_wvfLng
