### PR TITLE
fix(EgovDateUtil): 윤년 판정 반전·시간 포맷 인덱스 초과·날짜 변환 포맷 무시 수정

### DIFF
--- a/src/main/java/egovframework/let/utl/fcc/service/EgovDateUtil.java
+++ b/src/main/java/egovframework/let/utl/fcc/service/EgovDateUtil.java
@@ -267,8 +267,12 @@ public class EgovDateUtil {
 		}
 		if (EgovStringUtil.isNullToString(fromDateFormat).trim().equals(""))
 			_fromDateFormat = "yyyyMMddHHmmss"; // default값
+		else
+			_fromDateFormat = fromDateFormat;
 		if (EgovStringUtil.isNullToString(toDateFormat).trim().equals(""))
 			_toDateFormat = "yyyy-MM-dd HH:mm:ss"; // default값
+		else
+			_toDateFormat = toDateFormat;
 
 		try {
 			simpledateformat = new SimpleDateFormat(_fromDateFormat, Locale.getDefault());
@@ -354,7 +358,8 @@ public class EgovDateUtil {
 	 */
 	public static String formatTime(String sTime, String ch) {
 		String timeStr = validChkTime(sTime);
-		return timeStr.substring(0, 2) + ch + timeStr.substring(2, 4) + ch + timeStr.substring(4, 6);
+		// validChkTime은 4자리(HHmm)만 반환하므로 초 단위 분기는 도달할 수 없다.
+		return timeStr.substring(0, 2) + ch + timeStr.substring(2, 4);
 	}
 
 	/**
@@ -375,9 +380,9 @@ public class EgovDateUtil {
 	 * <p>입력받은 연도가 윤년인지 아닌지 검사한다.</p>
 	 *
 	 * <pre>
-	 * DateUtil.isLeapYear(2004) = false
-	 * DateUtil.isLeapYear(2005) = true
-	 * DateUtil.isLeapYear(2006) = true
+	 * DateUtil.isLeapYear(2004) = true
+	 * DateUtil.isLeapYear(2005) = false
+	 * DateUtil.isLeapYear(2006) = false
 	 * </pre>
 	 *
 	 * @param  year 연도
@@ -385,9 +390,9 @@ public class EgovDateUtil {
 	 */
 	public static boolean isLeapYear(int year) {
 		if (year % 4 == 0 && year % 100 != 0 || year % 400 == 0) {
-			return false;
+			return true;
 		}
-		return true;
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
egovframe-template-simple-backend에 이미 반영된 동일 수정을 본 템플릿에도 적용해 정합성을 맞춥니다.

- isLeapYear(int): 반환값이 반대(윤년→false, 평년→true)라 교정. 같은 클래스 leapYear()가 2004년에 "29"를 반환하는 점과 일치. Javadoc 예시도 정정(2004=true).
- formatTime(String,String): validChkTime()이 4자리(HHmm)만 반환하는데 substring(4,6) 호출로 모든 정상 입력에서 StringIndexOutOfBoundsException 발생 → 초 분기 제거.
- convertDate(4-arg): 호출자가 포맷을 넘겨도 else가 없어 빈 패턴이 사용되던 문제 → else 분기 추가.

## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

EgovDateUtil.java 3건(동일 파일):

1) isLeapYear(int): if/else 반환이 뒤바뀌어 윤년에 false, 평년에 true를 반환. 반환 교정 + Javadoc 예시 정정. (같은 클래스 leapYear()가 2004년에 "29"를 반환하는 것과 일치)
2) formatTime(String,String): validChkTime()이 항상 4자리(HHmm)를 반환하므로 substring(4,6)이 모든 정상 입력에서 StringIndexOutOfBoundsException. 초 세그먼트 제거.
3) convertDate(String,String,String,String): from/toDateFormat이 비어있지 않을 때 else 누락으로 지정 포맷이 무시되고 빈 패턴("")이 사용됨(파싱 실패 → NPE 또는 빈 문자열). else 분기 추가.

검증(standalone 컴파일·실행, 수정 전 실패 / 후 통과):
- isLeapYear(2004)=true, (2000)=true, (1900)=false, (2005)=false
- formatTime("1512", ":")="15:12"  (기존: 예외)
- convertDate("20260820","yyyyMMdd","yyyy-MM-dd","")="2026-08-20"  (기존: NPE)

동일 수정이 egovframe-template-simple-backend에 이미 반영되어 있어, 본 템플릿에도 정합성을 맞춥니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
