### PR TITLE
fix(bbs): 답글 등록에 검증이 걸리지 않아 필수값 위반이 그대로 저장됨

### DIFF
--- a/src/main/java/egovframework/let/cop/bbs/web/EgovBBSManageController.java
+++ b/src/main/java/egovframework/let/cop/bbs/web/EgovBBSManageController.java
@@ -445,7 +445,7 @@ public class EgovBBSManageController {
      */
     @PostMapping("/cop/bbs/replyBoardArticle.do")
     public String replyBoardArticle(final MultipartHttpServletRequest multiRequest, @ModelAttribute("searchVO") BoardVO boardVO,
-	    @ModelAttribute("bdMstr") BoardMaster bdMstr, @ModelAttribute("board") Board board, BindingResult bindingResult, ModelMap model,
+	    @ModelAttribute("bdMstr") BoardMaster bdMstr, @Valid @ModelAttribute("board") Board board, BindingResult bindingResult, ModelMap model,
 	    SessionStatus status, RedirectAttributes redirectAttributes) throws Exception {
 
     	// 사용자권한 처리


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

답글 등록(`POST /cop/bbs/replyBoardArticle.do`)에 검증이 걸리지 않습니다. `replyBoardArticle`은 `BindingResult`를 받아 `bindingResult.hasErrors()` 분기를 두지만 `@Valid`가 없어 그 분기로 들어가지 못합니다.

같은 컨트롤러의 형제 둘은 같은 `Board`에 `@Valid`를 붙입니다.

```java
insertBoardArticle(... @Valid @ModelAttribute("board") Board board ...)   // 검증 있음
updateBoardArticle(... @Valid @ModelAttribute("board") Board board ...)   // 검증 있음
replyBoardArticle (...       @ModelAttribute("board") Board board ...)    // 검증 없음
```

셋 다 `bbsMngService.insertBoardArticle(board)`로 게시글을 저장합니다. 답글만 검증을 건너뜁니다. `Board`는 `nttSj`에 `@Size(min=5)`, 그 외 필드에 `@EgovNullCheck`를 둡니다.

형제 둘과 같게 `@Valid`를 붙였습니다. 이미 있던 `hasErrors()` 분기가 그대로 답글쓰기 화면을 되돌려줍니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

앱을 띄우고(HSQL 내장) 관리자로 로그인해 부모글을 만든 뒤 제목을 다섯 자 미만(`@Size(min=5)` 위반)으로 답글을 등록했습니다.

수정 전

```
HTTP 302  Location: /cop/bbs/selectBoardList.do?...   (답글이 그대로 등록됨)
```

수정 후 — 같은 요청

```
HTTP 200  <title>공지사항 - 답글쓰기</title>            (답글쓰기 화면으로 되돌아옴, 등록 안 됨)
```

수정 후 — 필수값을 채운 정상 답글

```
HTTP 302  Location: /cop/bbs/selectBoardList.do?...   (정상 등록)
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

로컬에 띄운 인스턴스에 HTTP 요청을 보냈습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 응답 코드로 대신합니다.
