### PR TITLE
fix: 로그인 인터셉터가 미로그인 요청에 NPE 대신 로그인 페이지로 이동

### DIFF
--- a/src/main/java/egovframework/com/cmm/interceptor/AuthenticInterceptor.java
+++ b/src/main/java/egovframework/com/cmm/interceptor/AuthenticInterceptor.java
@@ -36,9 +36,9 @@ public class AuthenticInterceptor extends WebContentInterceptor {
 	 */
 	@Override
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws ServletException {
-		LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+		Object authenticatedUser = EgovUserDetailsHelper.getAuthenticatedUser();
 
-		if (loginVO.getId() != null) {
+		if (authenticatedUser instanceof LoginVO && ((LoginVO) authenticatedUser).getId() != null) {
 			return true;
 		} else {
 			ModelAndView modelAndView = new ModelAndView("redirect:/uat/uia/egovLoginUsr.do");


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

로그인 체크 인터셉터가 자기 Javadoc이 약속한 로그인 페이지 이동 대신 NPE를 냅니다.

`AuthenticInterceptor` 는 클래스 주석에 "계정정보(LoginVO)가 없다면, 로그인 페이지로 이동한다"고 적어 두었는데, 그 else 분기에 닿기 전 줄에서 null을 역참조합니다.

```java
LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
if (loginVO.getId() != null) {          // 미로그인이면 loginVO 가 null → NPE
    return true;
} else {
    ... "redirect:/uat/uia/egovLoginUsr.do" ...   // 도달 불가
}
```

미로그인 요청에서 `getAuthenticatedUser()` 는 세션 속성을 그대로 돌려주어 null 이고, `loginVO.getId()` 에서 NPE가 납니다. 그러면 `SimpleMappingExceptionResolver` 의 defaultErrorView(`cmm/error/egovError`)로 떨어지고, 약속된 로그인 페이지 리다이렉트는 실행되지 않습니다.

같은 클래스의 다른 진입점인 `EgovUserDetailsSessionServiceImpl.getAuthorities()` 는 정확히 이 경우를 `instanceof` → `getId() == null` 로 먼저 거릅니다. 그 형제와 같은 모양으로 맞췄습니다.

**AS-IS → TO-BE**

```java
Object authenticatedUser = EgovUserDetailsHelper.getAuthenticatedUser();
if (authenticatedUser instanceof LoginVO && ((LoginVO) authenticatedUser).getId() != null) {
    return true;
} else {
    ...
}
```

로그인된 요청에서는 이전과 동일하게 `getId() != null` 로 판정해 통과시키고, 미로그인·비-LoginVO 요청만 약속대로 로그인 페이지로 보냅니다. 한 파일, +2/-2 입니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

Tomcat 10.1 / JRE 17 에 WAR를 올리고(임베디드 hsqldb 시드) 미로그인 브라우저로 인터셉터 대상 URL을 열어 수정 전후를 대조했습니다. 인터셉터 매핑은 `/cop/com/*.do`, `/cop/bbs/*Master*.do`, `/uat/uia/*.do` 입니다.

| 요청(미로그인) | 수정 전 | 수정 후 |
|---|---|---|
| `/cop/com/selectBBSUseInfs.do` | HTTP 200, 에러 화면 | HTTP 302 → `/uat/uia/egovLoginUsr.do` |
| `/cop/bbs/SelectBBSMasterInfs.do` | HTTP 200, 에러 화면 | HTTP 302 → `/uat/uia/egovLoginUsr.do` |
| `/uat/uia/egovLoginUsr.do`(제외 경로) | HTTP 200 | HTTP 200 |

수정 전 서버 로그에 원인이 그대로 찍힙니다.

```
SimpleMappingExceptionResolver Resolved [java.lang.NullPointerException:
  Cannot invoke "egovframework.com.cmm.LoginVO.getId()" because "loginVO" is null]
  to ModelAndView [view="cmm/error/egovError"]
```

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

미로그인 상태로 `/cop/com/selectBBSUseInfs.do` 를 연 화면입니다.

**수정 전** — 에러 화면("알 수 없는 오류가 발생하였습니다")

![before](https://github.com/wantaekchoi/egovframe-simple-homepage-template/raw/pr-assets/interceptor-npe/before-error.png)

**수정 후** — 로그인 페이지로 이동

![after](https://github.com/wantaekchoi/egovframe-simple-homepage-template/raw/pr-assets/interceptor-npe/after-login.png)
