### PR TITLE
fix(mapper): 알티베이스 매퍼가 지정한 iBATIS 타입핸들러 제거

### DIFF
--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_altibase.xml
@@ -28,7 +28,7 @@
 		<result property="ntcrId" column="NTCR_ID"/>
 		<result property="ntcrNm" column="NTCR_NM"/>
 		<result property="nttNo" column="NTT_NO"/>
-		<result property="nttCn" column="NTT_CN" jdbcType="CLOB" typeHandler="egovframework.com.cmm.AltibaseClobStringTypeHandler"/>
+		<result property="nttCn" column="NTT_CN" jdbcType="CLOB"/>
 		<result property="password" column="PASSWORD"/>
 		<result property="frstRegisterId" column="FRST_REGISTER_ID"/>
 		<result property="frstRegisterNm" column="FRST_REGISTER_NM"/>
@@ -66,7 +66,7 @@
 		<result property="ntcrNm" column="NTCR_NM"/>
 		<result property="password" column="PASSWORD"/>
 		<result property="frstRegisterPnttm" column="FRST_REGIST_PNTTM"/>
-		<result property="nttCn" column="NTT_CN" jdbcType="CLOB" typeHandler="egovframework.com.cmm.AltibaseClobStringTypeHandler"/>
+		<result property="nttCn" column="NTT_CN" jdbcType="CLOB"/>
 		<result property="useAt" column="USE_AT"/>
 		<result property="frstRegisterNm" column="FRST_REGISTER_NM"/>
 		<result property="frstRegisterId" column="FRST_REGISTER_ID"/>

--- a/src/test/java/egovframework/test/EgovMapperTypeHandlerTest.java
+++ b/src/test/java/egovframework/test/EgovMapperTypeHandlerTest.java
@@ -1,0 +1,74 @@
+package egovframework.test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+/**
+ * 매퍼는 DB 타입과 무관하게 SqlSessionFactory 생성 단계를 통과한다.
+ *
+ * MyBatis는 매퍼를 파싱하면서 {@code typeHandler}로 지정된 클래스를 그 자리에서
+ * 인스턴스화한다. iBATIS 2 계약을 따르는 핸들러를 지정하면 그 초기화가 실패해
+ * 해당 DB 타입으로는 기동하지 못한다.
+ *
+ * {@code egovframework/spring/com/context-mapper.xml}의 sqlSession 빈과 같은
+ * configLocation·mapperLocations로 만든다.
+ *
+ * @author 최완택
+ * @since 2026-09-02
+ */
+@DisplayName("매퍼 타입핸들러")
+class EgovMapperTypeHandlerTest {
+
+	private static final String MAPPER_PATTERN = "classpath:/egovframework/mapper/let/**/*.xml";
+
+	private static final Pattern DB_TYPE = Pattern.compile("_([a-z]+)\\.xml$");
+
+	@Test
+	@DisplayName("모든 DB 타입에서 SqlSessionFactory 가 만들어진다")
+	void everyDbTypeBuildsSqlSessionFactory() throws IOException {
+		Set<String> dbTypes = dbTypes();
+		assertFalse(dbTypes.isEmpty(), "매퍼에서 DB 타입을 찾지 못했다: " + MAPPER_PATTERN);
+
+		for (String dbType : dbTypes) {
+			assertDoesNotThrow(() -> buildSqlSessionFactory(dbType), "Globals.DbType=" + dbType);
+		}
+	}
+
+	private Set<String> dbTypes() throws IOException {
+		Set<String> dbTypes = new TreeSet<>();
+		for (Resource resource : new PathMatchingResourcePatternResolver().getResources(MAPPER_PATTERN)) {
+			Matcher matcher = DB_TYPE.matcher(String.valueOf(resource.getFilename()));
+			if (matcher.find()) {
+				dbTypes.add(matcher.group(1));
+			}
+		}
+		return dbTypes;
+	}
+
+	private void buildSqlSessionFactory(String dbType) throws Exception {
+		PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+
+		SqlSessionFactoryBean sqlSessionFactoryBean = new SqlSessionFactoryBean();
+		sqlSessionFactoryBean.setDataSource(new UnpooledDataSource());
+		sqlSessionFactoryBean.setConfigLocation(
+			resolver.getResource("classpath:/egovframework/mapper/config/mapper-config.xml"));
+		sqlSessionFactoryBean.setMapperLocations(
+			resolver.getResources("classpath:/egovframework/mapper/let/**/*_" + dbType + ".xml"));
+
+		sqlSessionFactoryBean.afterPropertiesSet();
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

알티베이스 매퍼가 `typeHandler`로 `AltibaseClobStringTypeHandler`를 지정합니다.

```xml
<!-- EgovBoard_SQL_altibase.xml:31, :69 -->
<result property="nttCn" column="NTT_CN" jdbcType="CLOB" typeHandler="egovframework.com.cmm.AltibaseClobStringTypeHandler"/>
```

이 클래스가 구현하는 것은 MyBatis의 타입핸들러가 아니라 iBATIS 2의 동명 인터페이스입니다.

```
$ javap -cp "$(cat cp.txt)" org.egovframe.rte.psl.orm.ibatis.support.AbstractLobTypeHandler
public abstract class ...AbstractLobTypeHandler extends com.ibatis.sqlmap.engine.type.BaseTypeHandler {

$ javap -cp "$(cat cp.txt)" com.ibatis.sqlmap.engine.type.BaseTypeHandler
public abstract class com.ibatis.sqlmap.engine.type.BaseTypeHandler implements com.ibatis.sqlmap.engine.type.TypeHandler {
```

MyBatis는 매퍼를 파싱하면서 `typeHandler`로 지정된 클래스를 그 자리에서 인스턴스화합니다. 이 클래스는 초기화될 때 iBATIS 2 계약대로 설정 시점의 `LobHandler`를 찾으므로 거기서 끊깁니다. `context-mapper.xml`의 `sqlSession` 빈은 매퍼를 `classpath:/egovframework/mapper/let/**/*_${Globals.DbType}.xml`로 읽으니, `Globals.DbType=altibase`면 이 매퍼를 읽는 시점에 `SqlSessionFactory` 생성이 실패해 기동하지 못합니다.

여섯 변종을 같은 방식으로 만들어 보면 알티베이스만 갈립니다.

```
altibase  FAIL java.io.IOException: Failed to parse mapping resource: 'EgovBoard_SQL_altibase.xml'
   caused by org.apache.ibatis.builder.BuilderException: Error parsing Mapper XML
   caused by org.apache.ibatis.type.TypeException: Unable to find a usable constructor
             for class egovframework.com.cmm.AltibaseClobStringTypeHandler
   caused by java.lang.reflect.InvocationTargetException
   caused by java.lang.IllegalStateException: No LobHandler found for configuration
             - lobHandler property must be set on SqlMapClientFactoryBean
cubrid    OK
hsql      OK
mysql     OK
oracle    OK
tibero    OK
```

맨 아래 `LobHandler` 메시지만 보면 배선 문제로 읽히지만, `context-mapper.xml`은 `egov.lobHandler` 빈을 선언합니다. 끊기는 자리는 그 위의 `Unable to find a usable constructor`입니다.

같은 컬럼을 오라클 변종은 같은 줄에서 `jdbcType="CLOB"`만 두고 매핑합니다. 나머지 넷(mysql·cubrid·tibero·hsql)은 속성 자체가 없습니다. 오라클 쪽에 맞췄습니다.

AS-IS / TO-BE

```diff
-		<result property="nttCn" column="NTT_CN" jdbcType="CLOB" typeHandler="egovframework.com.cmm.AltibaseClobStringTypeHandler"/>
+		<result property="nttCn" column="NTT_CN" jdbcType="CLOB"/>
```

`jdbcType="CLOB"`은 그대로 두므로 CLOB 읽기 경로가 사라지지는 않습니다. MyBatis가 이 컬럼에 쓰는 핸들러는 자기 기본값이 됩니다.

```
$ (TypeHandlerRegistry 조회)
String + jdbcType=CLOB -> org.apache.ibatis.type.ClobTypeHandler
```

`typeHandler` 지정은 저장소 전체에서 이 두 줄뿐입니다. `AltibaseClobStringTypeHandler` 클래스는 참조가 없어지지만 삭제는 범위가 달라 이번 변경에 넣지 않았습니다.

같은 파일에 열려 있는 `#63`은 95·118·226행의 파라미터 표기를 고칩니다. 이번 변경은 31·69행의 속성이라 자리가 겹치지 않습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

DB 타입마다 `SqlSessionFactory`를 만들어 보는 테스트를 추가했습니다. `context-mapper.xml`의 `sqlSession` 빈과 같은 `configLocation`·`mapperLocations`로 만듭니다.

`pom.xml`의 surefire 설정이 `<skipTests>true</skipTests>`로 고정돼 있어 `-DskipTests=false`로는 덮어써지지 않습니다. 아래는 그 값을 잠시 `${skipTests}`로 열고 실행한 결과입니다. 원래대로 되돌려 두었고 CI 워크플로도 `-Dmaven.test.skip=true`를 넘기므로 이 테스트는 빌드에서 돌지 않습니다.

수정 전

```
$ mvn -Ptest -DskipTests=false test -Dtest=EgovMapperTypeHandlerTest
[ERROR]   EgovMapperTypeHandlerTest.everyDbTypeBuildsSqlSessionFactory:46
          Globals.DbType=altibase ==> Unexpected exception thrown: java.io.IOException:
          Failed to parse mapping resource: 'file [.../EgovBoard_SQL_altibase.xml]'
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

수정 후

```
$ mvn -Ptest -DskipTests=false test -Dtest=EgovMapperTypeHandlerTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

저장소 전체 테스트도 같이 돌렸습니다.

```
$ mvn -Ptest -DskipTests=false test
[INFO] Tests run: 46, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

`-Ptest` 없이 돌리면 기존 `EgovBBSAttributeManageControllerTestInsertBBSMasterInfTest`가 `NoClassDefFoundError: jakarta/servlet/ServletConnection`으로 실패합니다. `test` 프로필이 올리는 서블릿 API 6.0.0 대신 부모 pom의 5.0.0이 쓰여서이고, 이번 변경과는 무관합니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

알티베이스 환경이 없어 브라우저로 확인하지 못했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위와 같은 이유로 첨부하지 못했습니다.
