### PR TITLE
fix(cop/bbs): 게시판마스터 첨부 가능 파일 크기 설정이 등록되지 않아 무시되는 문제 수정

### DIFF
--- a/src/main/resources/egovframework/spring/com/context-properties.xml
+++ b/src/main/resources/egovframework/spring/com/context-properties.xml
@@ -18,7 +18,7 @@
             <map>
                 <entry key="pageUnit" value="10"/>
                 <entry key="pageSize" value="10"/>
-                <entry key="posblAtchFileSize" value="${Globals.fileUpload.maxRequestSize}"/>
+                <entry key="Globals.posblAtchFileSize" value="${Globals.posblAtchFileSize}"/>
                 <entry key="Globals.fileStorePath" value="${Globals.fileStorePath}"/>
                 <entry key="Globals.addedOptions" value="false"/>
             </map>

--- a/src/test/java/egovframework/let/cop/bbs/web/EgovBBSAttributeManageControllerPosblAtchFileSizeTest.java
+++ b/src/test/java/egovframework/let/cop/bbs/web/EgovBBSAttributeManageControllerPosblAtchFileSizeTest.java
@@ -1,0 +1,54 @@
+package egovframework.let.cop.bbs.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.egovframe.rte.fdl.property.EgovPropertyService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+import egovframework.test.EgovTestAbstractSpring;
+
+/**
+ * 게시판마스터 등록·수정이 조회하는 첨부 가능 파일 크기 프로퍼티 키 테스트
+ *
+ * @author 최완택
+ * @since 2026-09-02
+ */
+@ContextConfiguration(classes = { EgovBBSAttributeManageControllerPosblAtchFileSizeTest.class, EgovTestAbstractSpring.class })
+
+@Configuration
+
+class EgovBBSAttributeManageControllerPosblAtchFileSizeTest extends EgovTestAbstractSpring {
+
+	/** EgovBBSAttributeManageController 가 첨부 가능 파일 크기를 조회할 때 쓰는 키 */
+	private static final String KEY = "Globals.posblAtchFileSize";
+
+	/** globals.properties 경로 */
+	private static final String GLOBALS = "/egovframework/egovProps/globals.properties";
+
+	/** EgovPropertyService */
+	@Autowired
+	private EgovPropertyService propertyService;
+
+	@Test
+	@DisplayName("게시판마스터 등록·수정이 조회하는 키가 globals.properties 에 선언된 값을 돌려준다")
+	void testPosblAtchFileSizeIsResolvable() throws Exception {
+		final Properties globals = new Properties();
+		try (InputStream inputStream = getClass().getResourceAsStream(GLOBALS)) {
+			globals.load(inputStream);
+		}
+
+		assertNotNull(globals.getProperty(KEY), GLOBALS + " 에 " + KEY + " 선언이 없다");
+
+		assertEquals(globals.getProperty(KEY), propertyService.getString(KEY),
+				KEY + " 가 propertiesService 로 조회되지 않는다");
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`globals.properties`가 선언한 게시판 첨부 가능 파일 크기가 `propertiesService`에 등록되지 않아, 운영자가 값을 바꿔도 반영되지 않습니다.

게시판마스터를 등록·수정할 때는 `Globals.` 접두사가 붙은 이름으로 이 값을 조회합니다.

```java
// EgovBBSAttributeManageController.java:134, :238
String fileSize = propertyService.getString("Globals.posblAtchFileSize");
if (fileSize == null || fileSize.trim().isEmpty()) {
    fileSize = "10485760"; // 기본값: 10MB
}
boardMaster.setPosblAtchFileSize(fileSize);
```

맵에는 접두사 없는 이름으로 들어 있습니다. 조회가 `null`을 돌려주고 그 아래 폴백이 대신 쓰입니다.

```xml
<!-- context-properties.xml:21 -->
<entry key="posblAtchFileSize" value="${Globals.fileUpload.maxRequestSize}"/>
```

**배포 기본값에서는 겉으로 드러나지 않습니다.** `globals.properties`의 선언값과 위 폴백 리터럴이 둘 다 `10485760`이라 저장되는 값이 같습니다.

```properties
# globals.properties:63-64
# BBS File Attach Size
Globals.posblAtchFileSize = 10485760
```

운영자가 값을 바꾸면 드러납니다. `Globals.posblAtchFileSize = 1024`로 바꾸고 조회하면 선언한 값이 아니라 `null`이 돌아옵니다.

```
[ERROR] EgovBBSAttributeManageControllerPosblAtchFileSizeTest.testPosblAtchFileSizeIsResolvable:50
        Globals.posblAtchFileSize 가 propertiesService 로 조회되지 않는다 ==> expected: <1024> but was: <null>
```

5.0.0 이전에는 맵 키와 조회 키가 접두사 없는 이름으로 짝이 맞았습니다. 5.0.0에서 `globals.properties`에 이 항목을 새로 넣고 조회 키를 접두사 형태로 옮기면서, 같은 커밋에서 값을 갈아치운 이 엔트리의 키만 옛 이름으로 남았습니다.

```
$ git show 5e6167c^:src/main/resources/egovframework/spring/com/context-properties.xml | grep posbl
	        	<entry key="posblAtchFileSize" value="5242880"/>
$ git show 5e6167c^:src/main/java/egovframework/let/cop/bbs/web/EgovBBSAttributeManageController.java | grep -c 'getString("posblAtchFileSize")'
2
```

AS-IS / TO-BE

```diff
-                <entry key="posblAtchFileSize" value="${Globals.fileUpload.maxRequestSize}"/>
+                <entry key="Globals.posblAtchFileSize" value="${Globals.posblAtchFileSize}"/>
```

같은 맵의 `Globals.fileStorePath` 항목처럼 키 이름을 플레이스홀더 이름과 같게 맞췄습니다. 값도 함께 옮겨야 `globals.properties`의 선언이 실제로 쓰입니다. 키만 바꾸면 그 선언은 여전히 아무도 읽지 않습니다.

접두사 없는 이름을 프로퍼티 키로 조회하는 코드가 없어, 엔트리 이름을 바꿔도 끊기는 곳이 없습니다. JSP 세 곳의 `${bdMstr.posblAtchFileSize}`는 게시판마스터 레코드의 필드입니다.

```
$ git grep -l 'getString("posblAtchFileSize")'
(출력 없음)
```

바뀌는 것은 게시판마스터에 저장되는 `ATCH_POSBL_FILE_SIZE` 값 하나입니다. 기본 설정에서는 수정 전후 모두 `10485760`이라 동작이 같고, `globals.properties`를 바꾼 환경에서만 그 값이 반영됩니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovBBSAttributeManageControllerPosblAtchFileSizeTest`를 추가했습니다. 컨트롤러가 주입받는 것과 같은 `propertiesService` 빈에 조회 키를 물어, `globals.properties`가 선언한 값이 그대로 돌아오는지 봅니다.

이 저장소는 `pom.xml`의 surefire 설정이 `<skipTests>true</skipTests>`라 테스트가 실행되지 않습니다. 아래는 그 값을 잠시 해제하고 돌린 결과입니다.

```
$ mvn -Ptest test
[INFO] Tests run: 46, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

수정을 되돌리면 같은 자리에서 실패합니다.

```
[ERROR] EgovBBSAttributeManageControllerPosblAtchFileSizeTest.testPosblAtchFileSizeIsResolvable:50
        Globals.posblAtchFileSize 가 propertiesService 로 조회되지 않는다 ==> expected: <10485760> but was: <null>
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변화가 없는 설정 수정이라 첨부하지 않았습니다.
