### PR TITLE
fix(cop/smt/sim): 일정 등록 검증 실패 시 폼 재표시에 선택 목록이 복원되지 않는 문제 수정

### DIFF
--- a/src/main/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageController.java
+++ b/src/main/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageController.java
@@ -691,6 +691,28 @@ public class EgovIndvdlSchdulManageController {
 
     		if(bindingResult.hasErrors()){
 
+    	    	//공통코드  중요도 조회
+    	    	ComDefaultCodeVO voComCode = new ComDefaultCodeVO();
+    	    	voComCode.setCodeId("COM019");
+    	    	model.addAttribute("schdulIpcrCode", cmmUseService.selectCmmCodeDetail(voComCode));
+    	    	//공통코드  일정구분 조회
+    	    	voComCode = new ComDefaultCodeVO();
+    	    	voComCode.setCodeId("COM030");
+    	    	model.addAttribute("schdulSe", cmmUseService.selectCmmCodeDetail(voComCode));
+    	    	//공통코드  반복구분 조회
+    	    	voComCode = new ComDefaultCodeVO();
+    	    	voComCode.setCodeId("COM031");
+    	    	model.addAttribute("reptitSeCode", cmmUseService.selectCmmCodeDetail(voComCode));
+
+    	    	//일정시작일자(시)
+    	    	model.addAttribute("schdulBgndeHH", getTimeHH());
+    	    	//일정시작일자(분)
+    	    	model.addAttribute("schdulBgndeMM", getTimeMM());
+    	    	//일정종료일자(시)
+    	    	model.addAttribute("schdulEnddeHH", getTimeHH());
+    	    	//일정종료일자(분)
+    	    	model.addAttribute("schdulEnddeMM", getTimeMM());
+
     			return sLocationUrl;
     		}
 

--- a/src/test/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageControllerTestRegistActorTest.java
+++ b/src/test/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageControllerTestRegistActorTest.java
@@ -1,0 +1,94 @@
+package egovframework.let.cop.smt.sim.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.ui.ModelMap;
+import org.springframework.validation.BindingResult;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.test.EgovTestAbstractSpringMvc;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [일정관리][EgovIndvdlSchdulManageController.IndvdlSchdulManageRegistActor] Controller 단위 테스트
+ *
+ * @author 최완택
+ * @since 2026-09-02
+ *
+ */
+
+@RequiredArgsConstructor
+@Slf4j
+class EgovIndvdlSchdulManageControllerTestRegistActorTest extends EgovTestAbstractSpringMvc {
+
+	/**
+	 * 서버 검증에 걸려 등록 폼으로 되돌아갈 때 폼이 필요로 하는 목록이 모델에 남아 있어야 한다.
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	void test() throws Exception {
+		// given
+		final LoginVO loginVO = new LoginVO();
+		loginVO.setId("TEST1");
+		loginVO.setUniqId("USRCNFRM_00000000000");
+
+		final MockHttpSession session = new MockHttpSession();
+		session.setAttribute("LoginVO", loginVO);
+
+		// when 일정명을 비운 채 저장한다
+		final MvcResult mvcResult = mockMvc
+				.perform(multipart("/cop/smt/sim/EgovIndvdlSchdulManageRegistActor.do")
+
+						.session(session)
+
+						.param("cmd", "save")
+
+						.param("schdulSe", "1")
+						.param("schdulIpcrCode", "1")
+						.param("reptitSeCode", "1")
+						.param("schdulCn", "일정내용")
+						.param("schdulBgndeYYYMMDD", "2026-09-02")
+						.param("schdulEnddeYYYMMDD", "2026-09-02")
+						.param("schdulBgndeHH", "09")
+						.param("schdulBgndeMM", "00")
+						.param("schdulEnddeHH", "18")
+						.param("schdulEnddeMM", "00")
+						.param("schdulBgnde", "20260902090000")
+						.param("schdulEndde", "20260902180000")
+						.param("schdulDeptName", "관리자부서")
+						.param("schdulDeptId", "ORGNZT_0000000000000")
+						.param("schdulChargerName", "관리자")
+						.param("schdulChargerId", "USRCNFRM_00000000000"))
+
+				.andReturn();
+
+		// then 등록 폼으로 되돌아가되 셀렉트 박스를 채울 목록이 함께 담겨야 한다
+		final ModelMap modelMap = mvcResult.getModelAndView().getModelMap();
+
+		assertEquals("/cop/smt/sim/EgovIndvdlSchdulManageRegist", mvcResult.getModelAndView().getViewName(),
+				"검증에 걸리면 등록 폼으로 되돌아간다.");
+
+		final BindingResult bindingResult = (BindingResult) modelMap
+				.get(BindingResult.MODEL_KEY_PREFIX + "indvdlSchdulManageVO");
+		assertNotNull(bindingResult, "일정명이 비었으므로 검증 오류가 있어야 한다.");
+		assertTrue(bindingResult.hasFieldErrors("schdulNm"), "일정명이 비었으므로 검증 오류가 있어야 한다.");
+
+		for (final String attributeName : new String[] { "schdulSe", "schdulIpcrCode", "reptitSeCode", "schdulBgndeHH",
+				"schdulBgndeMM", "schdulEnddeHH", "schdulEnddeMM" }) {
+			assertNotNull(modelMap.get(attributeName), attributeName + " 목록이 없으면 폼의 선택 항목이 비어 다시 고를 수 없다.");
+		}
+
+		if (log.isDebugEnabled()) {
+			log.debug("test");
+		}
+	}
+
+}

--- a/src/test/java/egovframework/test/EgovTestAbstractSpringMvc.java
+++ b/src/test/java/egovframework/test/EgovTestAbstractSpringMvc.java
@@ -126,9 +126,9 @@ public class EgovTestAbstractSpringMvc {
 			if (log.isDebugEnabled()) {
 				log.debug("length={}", beanDefinitionNames.length);
 			}
-
-			mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
 		}
+
+		mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
 	}
 
 	/**


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

일정 등록에서 서버 검증에 걸려 폼으로 되돌아가면 선택 항목이 전부 비어 사용자가 값을 다시 고를 수 없습니다.

등록 폼을 여는 `IndvdlSchdulManageRegist`는 셀렉트를 채울 목록 일곱 개를 모델에 담습니다. 같은 컨트롤러의 수정 처리 `IndvdlSchdulManageModifyActor`도 검증 실패 분기에서 같은 일곱 개를 다시 담습니다.

```java
// EgovIndvdlSchdulManageController.java:534 (IndvdlSchdulManageModifyActor)
if(bindingResult.hasErrors()){

	//공통코드  중요도 조회
	ComDefaultCodeVO voComCode = new ComDefaultCodeVO();
	voComCode.setCodeId("COM019");
	model.addAttribute("schdulIpcrCode", cmmUseService.selectCmmCodeDetail(voComCode));
	... (COM030, COM031)

	//일정시작일자(시)
	model.addAttribute("schdulBgndeHH", getTimeHH());
	... (schdulBgndeMM, schdulEnddeHH, schdulEnddeMM)

	return sLocationUrl;
}
```

등록 처리 `IndvdlSchdulManageRegistActor`만 같은 분기에서 아무것도 담지 않습니다.

```java
// EgovIndvdlSchdulManageController.java:692 (IndvdlSchdulManageRegistActor)
if(bindingResult.hasErrors()){
	return sLocationUrl;
}
```

등록 화면의 셀렉트는 이 목록 말고 다른 공급원이 없습니다. 일정구분·중요도는 `<form:option value="" label="선택"/>`가 있어 "선택" 하나만 남지만, 시·분 네 개는 그 항목조차 없어 option 이 하나도 없는 `<select>`가 됩니다.

```jsp
<!-- EgovIndvdlSchdulManageRegist.jsp:341-343 -->
<form:select path="schdulBgndeHH">
    <form:options items="${schdulBgndeHH}" itemValue="code" itemLabel="codeNm"/>
</form:select>
```

시·분은 `@EgovNullCheck` 필수 항목입니다. 되돌아온 폼에서 사용자가 값을 고를 수단이 없으니 다시 저장해도 같은 검증 실패로 돌아옵니다. 수정 화면에서 같은 실수를 하면 제대로 복원됩니다.

AS-IS / TO-BE

폼 진입 핸들러와 형제 경로인 수정 처리가 담는 일곱 개를 등록 처리의 검증 실패 분기에서도 담습니다.

```diff
 		if(bindingResult.hasErrors()){
+
+	    	//공통코드  중요도 조회
+	    	ComDefaultCodeVO voComCode = new ComDefaultCodeVO();
+	    	voComCode.setCodeId("COM019");
+	    	model.addAttribute("schdulIpcrCode", cmmUseService.selectCmmCodeDetail(voComCode));
+	    	//공통코드  일정구분 조회
+	    	voComCode = new ComDefaultCodeVO();
+	    	voComCode.setCodeId("COM030");
+	    	model.addAttribute("schdulSe", cmmUseService.selectCmmCodeDetail(voComCode));
+	    	//공통코드  반복구분 조회
+	    	voComCode = new ComDefaultCodeVO();
+	    	voComCode.setCodeId("COM031");
+	    	model.addAttribute("reptitSeCode", cmmUseService.selectCmmCodeDetail(voComCode));
+
+	    	//일정시작일자(시)
+	    	model.addAttribute("schdulBgndeHH", getTimeHH());
+	    	//일정시작일자(분)
+	    	model.addAttribute("schdulBgndeMM", getTimeMM());
+	    	//일정종료일자(시)
+	    	model.addAttribute("schdulEnddeHH", getTimeHH());
+	    	//일정종료일자(분)
+	    	model.addAttribute("schdulEnddeMM", getTimeMM());
+
 			return sLocationUrl;
 		}
```

반복구분(`reptitSeCode`)은 등록 화면이 값을 고정한 라디오 버튼으로 그려 목록을 쓰지 않습니다. 폼 진입 핸들러와 수정 처리가 둘 다 담아 같은 구성으로 맞췄습니다.

바뀌는 것은 등록 처리가 검증 실패로 폼을 다시 그릴 때뿐입니다. 저장 경로와 수정 화면은 그대로입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`EgovIndvdlSchdulManageControllerTestRegistActorTest`를 추가했습니다. 일정명을 비운 채 등록을 요청해 등록 폼으로 되돌아오는지, 그 모델에 목록 일곱 개가 남아 있는지를 봅니다.

이 저장소는 `pom.xml`의 surefire 설정이 `<skipTests>true</skipTests>`라 테스트가 실행되지 않습니다. 아래는 그 값을 잠시 해제하고 돌린 결과입니다.

```
$ mvn -Ptest test
[INFO] Tests run: 46, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

수정한 블록을 도로 빼면 실패합니다.

```
[ERROR] EgovIndvdlSchdulManageControllerTestRegistActorTest.test:86
        schdulSe 목록이 없으면 폼의 선택 항목이 비어 다시 고를 수 없다. ==> expected: not <null>
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

같은 테스트가 뷰 이름과 `schdulNm` 검증 오류는 통과하므로, 요청이 핸들러에 닿아 검증에 걸린 뒤 등록 폼으로 되돌아간 상태에서 모델만 비어 있음을 확인할 수 있습니다.

### 테스트 기반 코드 한 줄

`EgovTestAbstractSpringMvc.setUp()`은 `mockMvc` 생성을 빈 이름 로깅용 static 가드 안에 둡니다. 그래서 MVC 테스트 클래스가 둘 이상이면 두 번째부터 `mockMvc`가 `null`입니다.

```diff
 			if (log.isDebugEnabled()) {
 				log.debug("length={}", beanDefinitionNames.length);
 			}
-
-			mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
 		}
+
+		mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
 	}
```

현재 MVC 테스트가 하나뿐이라 드러나지 않았습니다. 이 한 줄이 없으면 기존 `EgovBBSAttributeManageControllerTestInsertBBSMasterInfTest`가 깨집니다.

```
[ERROR] EgovBBSAttributeManageControllerTestInsertBBSMasterInfTest.test:35
        NullPointer Cannot invoke "MockMvc.perform(RequestBuilder)" because "this.mockMvc" is null
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

MockMvc 는 JSP 를 렌더하지 않아 화면 캡처 대신 모델 상태로 확인했습니다. 빈 `<select>` 는 위 JSP 의 공급원 근거입니다.
