### PR TITLE
refactor(exception): 포괄적 예외 선언을 제거

### DIFF
--- a/src/main/java/egovframework/com/cmm/RenewPaginationRenderer.java
+++ b/src/main/java/egovframework/com/cmm/RenewPaginationRenderer.java
@@ -15,7 +15,6 @@
  */
 package egovframework.com.cmm;
 
-import org.egovframe.rte.ptl.mvc.tags.ui.pagination.AbstractKrdsPaginationRenderer;
 import org.egovframe.rte.ptl.mvc.tags.ui.pagination.AbstractPaginationRenderer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
+++ b/src/main/java/egovframework/com/cmm/service/EgovFileMngUtil.java
@@ -12,8 +12,6 @@ import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.egovframe.rte.fdl.cmmn.exception.FdlException;
 import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
 import org.egovframe.rte.fdl.property.EgovPropertyService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -46,8 +44,6 @@ public class EgovFileMngUtil {
 
     @Resource(name = "egovFileIdGnrService")
     private EgovIdGnrService idgenService;
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(EgovFileMngUtil.class);
 
     /**
      * 첨부파일에 대한 목록 정보를 취득한다.

--- a/src/main/java/egovframework/let/cop/bbs/service/Board.java
+++ b/src/main/java/egovframework/let/cop/bbs/service/Board.java
@@ -3,10 +3,9 @@ package egovframework.let.cop.bbs.service;
 import java.io.Serializable;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
-
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
+
 import jakarta.validation.constraints.Size;
-import jakarta.validation.constraints.NotBlank;
 
 /**
  * 게시물에 대한 데이터 처리 모델 클래스

--- a/src/main/java/egovframework/let/main/web/EgovMainController.java
+++ b/src/main/java/egovframework/let/main/web/EgovMainController.java
@@ -45,11 +45,9 @@ public class EgovMainController {
 	 *
 	 * @param request
 	 * @param commandMap
-	 * @exception Exception Exception
 	 */
 	@RequestMapping(value = "/cmm/forwardPage.do")
-	public String forwardPageWithMenuNo(HttpServletRequest request, @RequestParam Map<String, Object> commandMap)
-	  throws Exception{
+	public String forwardPageWithMenuNo(HttpServletRequest request, @RequestParam Map<String, Object> commandMap) {
 		return "";
 	}
 
@@ -59,11 +57,9 @@ public class EgovMainController {
 	 *
 	 * @param request
 	 * @param model
-	 * @exception Exception Exception
 	 */
 	@RequestMapping(value = "/cmm/main/mainPage.do")
-	public String getMgtMainPage(HttpServletRequest request, ModelMap model)
-	  throws Exception{
+	public String getMgtMainPage(HttpServletRequest request, ModelMap model) {
 
 		// 공지사항 메인 컨텐츠 조회 시작 ---------------------------------
 		BoardVO boardVO = new BoardVO();

--- a/src/main/java/egovframework/let/sym/cal/service/EgovCalRestdeManageService.java
+++ b/src/main/java/egovframework/let/sym/cal/service/EgovCalRestdeManageService.java
@@ -26,108 +26,95 @@ public interface EgovCalRestdeManageService {
 	 * 일반달력 팝업 정보를 조회한다.
 	 * @param restde
 	 * @return List(일반달력 팝업 날짜정보)
-	 * @throws Exception
 	 */
-	List<?> selectNormalRestdePopup(Restde restde)	throws Exception;
+	List<?> selectNormalRestdePopup(Restde restde);
 
 	/**
 	 * 행정달력 팝업 정보를 조회한다.
 	 * @param restde
 	 * @return List(행정달력 팝업 날짜정보)
-	 * @throws Exception
 	 */
-	List<?> selectAdministRestdePopup(Restde restde)	throws Exception;
+	List<?> selectAdministRestdePopup(Restde restde);
 
 	/**
 	 * 일반달력 일간 정보를 조회한다.
 	 * @param restde
 	 * @return List(일반달력 일간 날짜정보)
-	 * @throws Exception
 	 */
-	List<?> selectNormalDayCal(Restde restde)	throws Exception;
+	List<?> selectNormalDayCal(Restde restde);
 
 	/**
 	 * 일반달력 일간 휴일을 조회한다.
 	 * @param restde
 	 * @return List(일반달력 일간 휴일정보)
-	 * @throws Exception
 	 */
-	List<?> selectNormalDayRestde(Restde restde)	throws Exception;
+	List<?> selectNormalDayRestde(Restde restde);
 
 	/**
 	 * 일반달력 월간 휴일을 조회한다.
 	 * @param restde
 	 * @return List(일반달력 월간 휴일정보)
-	 * @throws Exception
 	 */
-	List<?> selectNormalMonthRestde(Restde restde)	throws Exception;
+	List<?> selectNormalMonthRestde(Restde restde);
 
 	/**
 	 * 행정달력 일간 정보를 조회한다.
 	 * @param restde
 	 * @return List(행정달력 일간 날짜정보)
-	 * @throws Exception
 	 */
-	List<?> selectAdministDayCal(Restde restde)	throws Exception;
+	List<?> selectAdministDayCal(Restde restde);
 
 	/**
 	 * 행정달력 일간 휴일을 조회한다.
 	 * @param restde
 	 * @return List(행정달력 일간 휴일정보)
-	 * @throws Exception
 	 */
-	List<?> selectAdministDayRestde(Restde restde)	throws Exception;
+	List<?> selectAdministDayRestde(Restde restde);
 
 	/**
 	 * 행정달력 월간 휴일을 조회한다.
 	 * @param restde
 	 * @return List(행정달력 월간 휴일정보)
-	 * @throws Exception
 	 */
-	List<?> selectAdministMonthRestde(Restde restde)	throws Exception;
+	List<?> selectAdministMonthRestde(Restde restde);
 
 	/**
 	 * 휴일을 삭제한다.
 	 * @param restde
-	 * @throws Exception
 	 */
-	void deleteRestde(Restde restde) throws Exception;
+	void deleteRestde(Restde restde);
 
 	/**
 	 * 휴일을 등록한다.
 	 * @param restde
-	 * @throws Exception
 	 */
-	void insertRestde(Restde restde) throws Exception;
+	void insertRestde(Restde restde);
 
 	/**
 	 * 휴일 상세항목을 조회한다.
 	 * @param restde
 	 * @return Restde(휴일)
-	 * @throws Exception
 	 */
-	Restde selectRestdeDetail(Restde restde) throws Exception;
+	Restde selectRestdeDetail(Restde restde);
 
 	/**
 	 * 휴일 목록을 조회한다.
 	 * @param searchVO
 	 * @return List(휴일 목록)
-	 * @throws Exception
 	 */
-	List<?> selectRestdeList(RestdeVO searchVO) throws Exception;
+	List<?> selectRestdeList(RestdeVO searchVO);
 
     /**
      * 휴일 총 갯수를 조회한다.
      * @param searchVO
      * @return int(휴일 총 갯수)
      */
-    int selectRestdeListTotCnt(RestdeVO searchVO) throws Exception;
+    int selectRestdeListTotCnt(RestdeVO searchVO);
 
 	/**
 	 * 휴일을 수정한다.
 	 * @param restde
-	 * @throws Exception
 	 */
-	void updateRestde(Restde restde) throws Exception;
+	void updateRestde(Restde restde);
 
 }

--- a/src/main/java/egovframework/let/sym/cal/service/impl/EgovCalRestdeManageServiceImpl.java
+++ b/src/main/java/egovframework/let/sym/cal/service/impl/EgovCalRestdeManageServiceImpl.java
@@ -38,7 +38,7 @@ public class EgovCalRestdeManageServiceImpl extends EgovAbstractServiceImpl impl
 	 * 일반달력 팝업 정보를 조회한다.
 	 */
     @Override
-	public List<?> selectNormalRestdePopup(Restde restde) throws Exception {
+	public List<?> selectNormalRestdePopup(Restde restde) {
 		return restdeManageDAO.selectNormalRestdePopup(restde);
 	}
 
@@ -46,7 +46,7 @@ public class EgovCalRestdeManageServiceImpl extends EgovAbstractServiceImpl impl
 	 * 행정달력 팝업 정보를 조회한다.
 	 */
     @Override
-	public List<?> selectAdministRestdePopup(Restde restde) throws Exception {
+	public List<?> selectAdministRestdePopup(Restde restde) {
 		return restdeManageDAO.selectAdministRestdePopup(restde);
 	}
 
@@ -54,7 +54,7 @@ public class EgovCalRestdeManageServiceImpl extends EgovAbstractServiceImpl impl
 	 * 일반달력 일간 정보를 조회한다.
 	 */
     @Override
-	public List<?> selectNormalDayCal(Restde restde) throws Exception {
+	public List<?> selectNormalDayCal(Restde restde) {
 		return restdeManageDAO.selectNormalDayCal(restde);
 	}
 
@@ -62,7 +62,7 @@ public class EgovCalRestdeManageServiceImpl extends EgovAbstractServiceImpl impl
 	 * 일반달력 일간 휴일을 조회한다.
 	 */
     @Override
-	public List<?> selectNormalDayRestde(Restde restde) throws Exception {
+	public List<?> selectNormalDayRestde(Restde restde) {
 		return restdeManageDAO.selectNormalDayRestde(restde);
 	}
 
@@ -70,7 +70,7 @@ public class EgovCalRestdeManageServiceImpl extends EgovAbstractServiceImpl impl
 	 * 일반달력 월간 휴일을 조회한다.
 	 */
     @Override
-	public List<?> selectNormalMonthRestde(Restde restde) throws Exception {
+	public List<?> selectNormalMonthRestde(Restde restde) {
 		return restdeManageDAO.selectNormalMonthRestde(restde);
 	}
 
@@ -78,7 +78,7 @@ public class EgovCalRestdeManageServiceImpl extends EgovAbstractServiceImpl impl
 	 * 행정달력 일간 정보를 조회한다.
 	 */
     @Override
-	public List<?> selectAdministDayCal(Restde restde) throws Exception {
+	public List<?> selectAdministDayCal(Restde restde) {
 		return restdeManageDAO.selectAdministDayCal(restde);
 	}
 
@@ -86,7 +86,7 @@ public class EgovCalRestdeManageServiceImpl extends EgovAbstractServiceImpl impl
 	 * 행정달력 일간 휴일을 조회한다.
 	 */
     @Override
-	public List<?> selectAdministDayRestde(Restde restde) throws Exception {
+	public List<?> selectAdministDayRestde(Restde restde) {
 		return restdeManageDAO.selectAdministDayRestde(restde);
 	}
 
@@ -94,7 +94,7 @@ public class EgovCalRestdeManageServiceImpl extends EgovAbstractServiceImpl impl
 	 * 행정달력 월간 휴일을 조회한다.
 	 */
     @Override
-	public List<?> selectAdministMonthRestde(Restde restde) throws Exception {
+	public List<?> selectAdministMonthRestde(Restde restde) {
 		return restdeManageDAO.selectAdministMonthRestde(restde);
 	}
 
@@ -102,7 +102,7 @@ public class EgovCalRestdeManageServiceImpl extends EgovAbstractServiceImpl impl
 	 * 휴일을 삭제한다.
 	 */
 	@Override
-	public void deleteRestde(Restde restde) throws Exception {
+	public void deleteRestde(Restde restde) {
 		restdeManageDAO.deleteRestde(restde);
 	}
 
@@ -110,7 +110,7 @@ public class EgovCalRestdeManageServiceImpl extends EgovAbstractServiceImpl impl
 	 * 휴일을 등록한다.
 	 */
 	@Override
-	public void insertRestde(Restde restde) throws Exception {
+	public void insertRestde(Restde restde) {
     	restdeManageDAO.insertRestde(restde);
 	}
 
@@ -118,7 +118,7 @@ public class EgovCalRestdeManageServiceImpl extends EgovAbstractServiceImpl impl
 	 * 휴일 상세항목을 조회한다.
 	 */
 	@Override
-	public Restde selectRestdeDetail(Restde restde) throws Exception {
+	public Restde selectRestdeDetail(Restde restde) {
     	Restde ret = restdeManageDAO.selectRestdeDetail(restde);
     	return ret;
 	}
@@ -127,7 +127,7 @@ public class EgovCalRestdeManageServiceImpl extends EgovAbstractServiceImpl impl
 	 * 휴일 목록을 조회한다.
 	 */
 	@Override
-	public List<?> selectRestdeList(RestdeVO searchVO) throws Exception {
+	public List<?> selectRestdeList(RestdeVO searchVO) {
         return restdeManageDAO.selectRestdeList(searchVO);
 	}
 
@@ -135,7 +135,7 @@ public class EgovCalRestdeManageServiceImpl extends EgovAbstractServiceImpl impl
 	 * 휴일 총 갯수를 조회한다.
 	 */
 	@Override
-	public int selectRestdeListTotCnt(RestdeVO searchVO) throws Exception {
+	public int selectRestdeListTotCnt(RestdeVO searchVO) {
         return restdeManageDAO.selectRestdeListTotCnt(searchVO);
 	}
 
@@ -143,7 +143,7 @@ public class EgovCalRestdeManageServiceImpl extends EgovAbstractServiceImpl impl
 	 * 휴일을 수정한다.
 	 */
 	@Override
-	public void updateRestde(Restde restde) throws Exception {
+	public void updateRestde(Restde restde) {
 		restdeManageDAO.updateRestde(restde);
 	}
 

--- a/src/main/java/egovframework/let/sym/cal/web/EgovCalRestdeManageController.java
+++ b/src/main/java/egovframework/let/sym/cal/web/EgovCalRestdeManageController.java
@@ -41,11 +41,10 @@ public class EgovCalRestdeManageController {
 	 * 일반달력 팝업 메인창을 호출한다.
 	 * @param model
 	 * @return "/cmm/sym/cal/EgovNormalCalPopup"
-	 * @throws Exception
 	 */
 	@RequestMapping(value="/sym/cmm/EgovNormalCalPopup.do")
  	public String callNormalCalPopup (ModelMap model
- 			) throws Exception {
+ 			) {
 		return "/cmm/sym/cal/EgovNormalCalPopup";
 	}    
 
@@ -54,12 +53,11 @@ public class EgovCalRestdeManageController {
 	 * @param restde
 	 * @param model
 	 * @return "/cmm/sym/cal/EgovNormalCalendar"
-	 * @throws Exception
 	 */
 	@RequestMapping(value="/sym/cmm/EgovselectNormalCalendar.do")
  	public String selectNormalRestdePopup (Restde restde
  			, ModelMap model
- 			) throws Exception {
+ 			) {
 
 		Calendar cal = Calendar.getInstance();
 

--- a/src/main/java/egovframework/let/uat/uia/service/EgovLoginService.java
+++ b/src/main/java/egovframework/let/uat/uia/service/EgovLoginService.java
@@ -25,23 +25,20 @@ public interface EgovLoginService {
 	 * 일반 로그인을 처리한다
 	 * @param vo LoginVO
 	 * @return LoginVO
-	 * @exception Exception
 	 */
-    LoginVO actionLogin(LoginVO vo) throws Exception;
+    LoginVO actionLogin(LoginVO vo);
     
     /**
 	 * 아이디를 찾는다.
 	 * @param vo LoginVO
 	 * @return LoginVO
-	 * @exception Exception
 	 */
-    LoginVO searchId(LoginVO vo) throws Exception;
+    LoginVO searchId(LoginVO vo);
     
     /**
 	 * 비밀번호를 찾는다.
 	 * @param vo LoginVO
 	 * @return boolean
-	 * @exception Exception
 	 */
-    boolean searchPassword(LoginVO vo) throws Exception;
+    boolean searchPassword(LoginVO vo);
 }

--- a/src/main/java/egovframework/let/uat/uia/service/impl/EgovLoginServiceImpl.java
+++ b/src/main/java/egovframework/let/uat/uia/service/impl/EgovLoginServiceImpl.java
@@ -37,10 +37,9 @@ public class EgovLoginServiceImpl extends EgovAbstractServiceImpl implements Ego
 	 * 일반 로그인을 처리한다
 	 * @param vo LoginVO
 	 * @return LoginVO
-	 * @exception Exception
 	 */
 	@Override
-	public LoginVO actionLogin(LoginVO vo) throws Exception {
+	public LoginVO actionLogin(LoginVO vo) {
 
 		// 1. 입력한 비밀번호를 암호화한다.
 		String enpassword = EgovFileScrty.encryptPassword(vo.getPassword(), vo.getId());
@@ -63,10 +62,9 @@ public class EgovLoginServiceImpl extends EgovAbstractServiceImpl implements Ego
 	 * 아이디를 찾는다.
 	 * @param vo LoginVO
 	 * @return LoginVO
-	 * @exception Exception
 	 */
 	@Override
-	public LoginVO searchId(LoginVO vo) throws Exception {
+	public LoginVO searchId(LoginVO vo) {
 
 		// 1. 이름, 이메일주소가 DB와 일치하는 사용자 ID를 조회한다.
 		LoginVO loginVO = loginDAO.searchId(vo);
@@ -85,10 +83,9 @@ public class EgovLoginServiceImpl extends EgovAbstractServiceImpl implements Ego
 	 * 비밀번호를 찾는다.
 	 * @param vo LoginVO
 	 * @return boolean
-	 * @exception Exception
 	 */
 	@Override
-	public boolean searchPassword(LoginVO vo) throws Exception {
+	public boolean searchPassword(LoginVO vo) {
 
 		boolean result = true;
 

--- a/src/main/java/egovframework/let/uat/uia/web/EgovLoginController.java
+++ b/src/main/java/egovframework/let/uat/uia/web/EgovLoginController.java
@@ -57,10 +57,9 @@ public class EgovLoginController {
 	 * 로그인 화면으로 들어간다
 	 * @param vo - 로그인후 이동할 URL이 담긴 LoginVO
 	 * @return 로그인 페이지
-	 * @exception Exception
 	 */
 	@RequestMapping(value = "/uat/uia/egovLoginUsr.do")
-	public String loginUsrView(@ModelAttribute("loginVO") LoginVO loginVO, HttpServletRequest request, HttpServletResponse response, ModelMap model) throws Exception {
+	public String loginUsrView(@ModelAttribute("loginVO") LoginVO loginVO, HttpServletRequest request, HttpServletResponse response, ModelMap model) {
 		return "cmm/uat/uia/EgovLoginUsr";
 	}
 
@@ -69,10 +68,9 @@ public class EgovLoginController {
 	 * @param vo - 아이디, 비밀번호가 담긴 LoginVO
 	 * @param request - 세션처리를 위한 HttpServletRequest
 	 * @return result - 로그인결과(세션정보)
-	 * @exception Exception
 	 */
 	@RequestMapping(value = "/uat/uia/actionLogin.do", method = RequestMethod.POST)
-	public String actionLogin(@ModelAttribute("loginVO") LoginVO loginVO, HttpServletRequest request, ModelMap model) throws Exception {
+	public String actionLogin(@ModelAttribute("loginVO") LoginVO loginVO, HttpServletRequest request, ModelMap model) {
 		// 일반 로그인 처리
 		LoginVO resultVO = loginService.actionLogin(loginVO);
 
@@ -89,10 +87,9 @@ public class EgovLoginController {
 	 * 로그인 후 메인화면으로 들어간다
 	 * @param
 	 * @return 로그인 페이지
-	 * @exception Exception
 	 */
 	@RequestMapping(value = "/uat/uia/actionMain.do")
-	public String actionMain(ModelMap model) throws Exception {
+	public String actionMain(ModelMap model) {
 		// 1. 사용자 인증 처리
 		Boolean isAuthenticated = EgovUserDetailsHelper.isAuthenticated();
 		if (!isAuthenticated) {
@@ -107,10 +104,9 @@ public class EgovLoginController {
 	/**
 	 * 로그아웃한다.
 	 * @return String
-	 * @exception Exception
 	 */
 	@RequestMapping(value = "/uat/uia/actionLogout.do", method = RequestMethod.POST)
-	public String actionLogout(HttpServletRequest request) throws Exception {
+	public String actionLogout(HttpServletRequest request) {
 		HttpSession session = request.getSession(false);
 	    if (session != null) {
 	        session.invalidate();

--- a/src/main/java/egovframework/let/utl/fcc/service/EgovFileUploadUtil.java
+++ b/src/main/java/egovframework/let/utl/fcc/service/EgovFileUploadUtil.java
@@ -1,11 +1,13 @@
 package egovframework.let.utl.fcc.service;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 import org.springframework.web.util.WebUtils;
@@ -39,10 +41,8 @@ public class EgovFileUploadUtil extends EgovFormBasedFileUtil {
 	 * @param where
 	 * @param maxFileSize
 	 * @return
-	 * @throws Exception
 	 */
-	public static List<EgovFormBasedFileVo> uploadFiles(HttpServletRequest request, String where, long maxFileSize)
-		throws Exception {
+	public static List<EgovFormBasedFileVo> uploadFiles(HttpServletRequest request, String where, long maxFileSize) {
 		List<EgovFormBasedFileVo> list = new ArrayList<EgovFormBasedFileVo>();
 
 		//MultipartHttpServletRequest mptRequest = (MultipartHttpServletRequest) request;
@@ -79,9 +79,15 @@ public class EgovFileUploadUtil extends EgovFormBasedFileUtil {
 							is = mFile.getInputStream();
 							saveFile(is, new File(EgovWebUtil.filePathBlackList(
 								where + SEPERATOR + vo.getServerSubPath() + SEPERATOR + vo.getPhysicalName())));
+						} catch (IOException e) {
+							throw new BaseRuntimeException(e);
 						} finally {
 							if (is != null) {
-								is.close();
+								try {
+									is.close();
+								} catch (IOException e) {
+									throw new BaseRuntimeException(e);
+								}
 							}
 						}
 						list.add(vo);
@@ -100,10 +106,9 @@ public class EgovFileUploadUtil extends EgovFormBasedFileUtil {
 	 * @param where
 	 * @param maxFileSize
 	 * @return
-	 * @throws Exception
 	 */
 	public static List<EgovFormBasedFileVo> uploadFilesExt(MultipartHttpServletRequest mptRequest, String where,
-		long maxFileSize, String extensionWhiteList) throws Exception {
+		long maxFileSize, String extensionWhiteList) {
 		List<EgovFormBasedFileVo> list = new ArrayList<EgovFormBasedFileVo>();
 
 		if (mptRequest != null) {
@@ -147,9 +152,15 @@ public class EgovFileUploadUtil extends EgovFormBasedFileUtil {
 							is = mFile.getInputStream();
 							saveFile(is, new File(EgovWebUtil.filePathBlackList(
 								where + SEPERATOR + vo.getServerSubPath() + SEPERATOR + vo.getPhysicalName())));
+						} catch (IOException e) {
+							throw new BaseRuntimeException(e);
 						} finally {
 							if (is != null) {
-								is.close();
+								try {
+									is.close();
+								} catch (IOException e) {
+									throw new BaseRuntimeException(e);
+								}
 							}
 						}
 						list.add(vo);

--- a/src/main/java/egovframework/let/utl/fcc/service/EgovFormBasedFileUtil.java
+++ b/src/main/java/egovframework/let/utl/fcc/service/EgovFormBasedFileUtil.java
@@ -4,7 +4,6 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -13,6 +12,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,9 +67,8 @@ public class EgovFormBasedFileUtil {
 	 * 파일명 변환.
 	 * @param filename String
 	 * @return
-	 * @throws Exception
 	 */
-	protected static String convert(String filename) throws Exception {
+	protected static String convert(String filename) {
 		//return java.net.URLEncoder.encode(filename, "utf-8");
 		return filename;
 	}
@@ -78,7 +77,6 @@ public class EgovFormBasedFileUtil {
 	 * Stream으로부터 파일을 저장함.
 	 * @param is InputStream
 	 * @param file File
-	 * @throws IOException
 	 */
 	public static long saveFile(InputStream is, File file) throws IOException {
 		//KISA 보안약점 조치 (2018-10-29, 윤창원)
@@ -125,10 +123,9 @@ public class EgovFormBasedFileUtil {
 	 * @param where
 	 * @param maxFileSize
 	 * @return
-	 * @throws Exception
 	 */
 	/*
-	public static List<EgovFormBasedFileVo> uploadFiles(HttpServletRequest request, String where, long maxFileSize) throws Exception {
+	public static List<EgovFormBasedFileVo> uploadFiles(HttpServletRequest request, String where, long maxFileSize) {
 		List<EgovFormBasedFileVo> list = new ArrayList<EgovFormBasedFileVo>();
 
 		// Check that we have a file upload request
@@ -194,19 +191,18 @@ public class EgovFormBasedFileUtil {
 	 * @param serverSubPath
 	 * @param physicalName
 	 * @param original
-	 * @throws Exception
 	 */
-	public static void downloadFile(HttpServletResponse response, String where, String serverSubPath, String physicalName, String original) throws Exception {
+	public static void downloadFile(HttpServletResponse response, String where, String serverSubPath, String physicalName, String original) {
 		String downFileName = where + SEPERATOR + serverSubPath + SEPERATOR + physicalName;
 
 		File file = new File(EgovWebUtil.filePathBlackList(downFileName));
 
 		if (!file.exists()) {
-			throw new FileNotFoundException(downFileName);
+			throw new BaseRuntimeException(downFileName);
 		}
 
 		if (!file.isFile()) {
-			throw new FileNotFoundException(downFileName);
+			throw new BaseRuntimeException(downFileName);
 		}
 
 		byte[] b = new byte[BUFFER_SIZE];
@@ -230,6 +226,8 @@ public class EgovFormBasedFileUtil {
 			while ((read = fin.read(b)) != -1) {
 				outs.write(b, 0, read);
 			}
+		} catch (IOException e) {
+			throw new BaseRuntimeException(e);
 		} finally {
 			EgovResourceCloseHelper.close(outs, fin);
 		}
@@ -246,20 +244,19 @@ public class EgovFormBasedFileUtil {
 	 * @param serverSubPath
 	 * @param physicalName
 	 * @param mimeType
-	 * @throws Exception
 	 */
-	public static void viewFile(HttpServletResponse response, String where, String serverSubPath, String physicalName, String mimeTypeParam) throws Exception {
+	public static void viewFile(HttpServletResponse response, String where, String serverSubPath, String physicalName, String mimeTypeParam) {
 		String mimeType = mimeTypeParam;
 		String downFileName = where + SEPERATOR + serverSubPath + SEPERATOR + physicalName;
 
 		File file = new File(EgovWebUtil.filePathBlackList(downFileName));
 
 		if (!file.exists()) {
-			throw new FileNotFoundException(downFileName);
+			throw new BaseRuntimeException(downFileName);
 		}
 
 		if (!file.isFile()) {
-			throw new FileNotFoundException(downFileName);
+			throw new BaseRuntimeException(downFileName);
 		}
 
 		byte[] b = new byte[BUFFER_SIZE];
@@ -283,6 +280,8 @@ public class EgovFormBasedFileUtil {
 			while ((read = fin.read(b)) != -1) {
 				outs.write(b, 0, read);
 			}
+		} catch (IOException e) {
+			throw new BaseRuntimeException(e);
 		} finally {
 			EgovResourceCloseHelper.close(outs, fin);
 		}

--- a/src/main/java/egovframework/let/utl/sim/service/EgovFileScrty.java
+++ b/src/main/java/egovframework/let/utl/sim/service/EgovFileScrty.java
@@ -9,8 +9,10 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 import org.apache.commons.codec.binary.Base64;
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +50,7 @@ public class EgovFileScrty {
 	 * @return boolean result 암호화여부 True/False
 	 * @exception Exception
 	 */
-	public static boolean encryptFile(String source, String target) throws Exception {
+	public static boolean encryptFile(String source, String target) {
 
 		// 암호화 여부
 		boolean result = false;
@@ -78,6 +80,8 @@ public class EgovFileScrty {
 
 				result = true;
 			}
+		} catch (IOException e) {
+			throw new BaseRuntimeException(e);
 		} finally {
 			if (input != null) {
 				try {
@@ -105,7 +109,7 @@ public class EgovFileScrty {
 	 * @return boolean result 복호화여부 True/False
 	 * @exception Exception
 	 */
-	public static boolean decryptFile(String source, String target) throws Exception {
+	public static boolean decryptFile(String source, String target) {
 
 		// 복호화 여부
 		boolean result = false;
@@ -133,6 +137,8 @@ public class EgovFileScrty {
 
 				result = true;
 			}
+		} catch (IOException e) {
+			throw new BaseRuntimeException(e);
 		} finally {
 			if (input != null) {
 				try {
@@ -159,7 +165,7 @@ public class EgovFileScrty {
 	 * @return String result 암호화된 데이터
 	 * @exception Exception
 	 */
-	public static String encodeBinary(byte[] data) throws Exception {
+	public static String encodeBinary(byte[] data) {
 		if (data == null) {
 			return "";
 		}
@@ -174,7 +180,7 @@ public class EgovFileScrty {
 	 * @return String result 암호화된 데이터
 	 * @exception Exception
 	 */
-	public static String encode(String data) throws Exception {
+	public static String encode(String data) {
 		return encodeBinary(data.getBytes());
 	}
 
@@ -185,7 +191,7 @@ public class EgovFileScrty {
 	 * @return String result 복호화된 데이터
 	 * @exception Exception
 	 */
-	public static byte[] decodeBinary(String data) throws Exception {
+	public static byte[] decodeBinary(String data) {
 		return Base64.decodeBase64(data.getBytes());
 	}
 
@@ -196,7 +202,7 @@ public class EgovFileScrty {
 	 * @return String result 복호화된 데이터
 	 * @exception Exception
 	 */
-	public static String decode(String data) throws Exception {
+	public static String decode(String data) {
 		return new String(decodeBinary(data));
 	}
 
@@ -210,7 +216,7 @@ public class EgovFileScrty {
      * @exception Exception
      */
     @Deprecated
-    public static String encryptPassword(String data) throws Exception {
+    public static String encryptPassword(String data) {
 
 		if (data == null) {
 		    return "";
@@ -220,7 +226,12 @@ public class EgovFileScrty {
 		byte[] hashValue = null; // 해쉬값
 		plainText = data.getBytes();
 	
-		MessageDigest md = MessageDigest.getInstance("SHA-256");
+		MessageDigest md;
+		try {
+			md = MessageDigest.getInstance("SHA-256");
+		} catch (NoSuchAlgorithmException e) {
+			throw new BaseRuntimeException(e);
+		}
 		
 		// 변경 시 기존 hash 값에 검증 불가.. => deprecated 시키고 유지
 		/*	
@@ -248,9 +259,8 @@ public class EgovFileScrty {
      * @param password 암호화될 패스워드
      * @param id salt로 사용될 사용자 ID 지정
      * @return
-     * @throws Exception
      */
-    public static String encryptPassword(String password, String id) throws Exception {
+    public static String encryptPassword(String password, String id) {
 
 		if (password == null) {
 		    return "";
@@ -258,7 +268,12 @@ public class EgovFileScrty {
 	
 		byte[] hashValue = null; // 해쉬값
 	
-		MessageDigest md = MessageDigest.getInstance("SHA-256");
+		MessageDigest md;
+		try {
+			md = MessageDigest.getInstance("SHA-256");
+		} catch (NoSuchAlgorithmException e) {
+			throw new BaseRuntimeException(e);
+		}
 		
 		md.reset();
 		md.update(id.getBytes());
@@ -273,9 +288,8 @@ public class EgovFileScrty {
      * @param data 암호화할 비밀번호
      * @param salt Salt
      * @return 암호화된 비밀번호
-     * @throws Exception
      */
-    public static String encryptPassword(String data, byte[] salt) throws Exception {
+    public static String encryptPassword(String data, byte[] salt) {
 
 		if (data == null) {
 		    return "";
@@ -283,7 +297,12 @@ public class EgovFileScrty {
 	
 		byte[] hashValue = null; // 해쉬값
 	
-		MessageDigest md = MessageDigest.getInstance("SHA-256");
+		MessageDigest md;
+		try {
+			md = MessageDigest.getInstance("SHA-256");
+		} catch (NoSuchAlgorithmException e) {
+			throw new BaseRuntimeException(e);
+		}
 		
 		md.reset();
 		md.update(salt);
@@ -299,12 +318,16 @@ public class EgovFileScrty {
      * @param data 원 패스워드
      * @param encoded 해쉬처리된 패스워드(Base64 인코딩)
      * @return
-     * @throws Exception
      */
-    public static boolean checkPassword(String data, String encoded, byte[] salt) throws Exception {
+    public static boolean checkPassword(String data, String encoded, byte[] salt) {
     	byte[] hashValue = null; // 해쉬값
     	
-    	MessageDigest md = MessageDigest.getInstance("SHA-256");
+    	MessageDigest md;
+		try {
+			md = MessageDigest.getInstance("SHA-256");
+		} catch (NoSuchAlgorithmException e) {
+			throw new BaseRuntimeException(e);
+		}
     	
     	md.reset();
     	md.update(salt);

--- a/src/test/java/egovframework/let/cop/bbs/service/impl/BBSAttributeManageDAOTestInsertBBSMasterInfTest.java
+++ b/src/test/java/egovframework/let/cop/bbs/service/impl/BBSAttributeManageDAOTestInsertBBSMasterInfTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
@@ -48,12 +47,9 @@ class BBSAttributeManageDAOTestInsertBBSMasterInfTest extends EgovTestAbstractSp
 
 	/**
 	 * 신규 게시판 속성정보를 등록한다.
-	 * 
-	 * @throws BaseRuntimeException
-	 * @throws Exception
 	 */
 	@Test
-	void test() throws BaseRuntimeException, Exception {
+	void test() {
 		// given
 		final BoardMaster boardMaster = new BoardMaster();
 

--- a/src/test/java/egovframework/let/cop/bbs/service/impl/EgovBBSAttributeManageServiceImplTestInsertBBSMastetInfTest.java
+++ b/src/test/java/egovframework/let/cop/bbs/service/impl/EgovBBSAttributeManageServiceImplTestInsertBBSMastetInfTest.java
@@ -59,11 +59,9 @@ class EgovBBSAttributeManageServiceImplTestInsertBBSMastetInfTest extends EgovTe
 
 	/**
 	 * 신규 게시판 속성정보를 생성한다.
-	 * 
-	 * @throws Exception
 	 */
 	@Test
-	void test() throws Exception {
+	void test() {
 		// given
 		final BoardMaster boardMaster = new BoardMaster();
 

--- a/src/test/java/egovframework/let/cop/bbs/web/EgovBBSAttributeManageControllerPosblAtchFileSizeTest.java
+++ b/src/test/java/egovframework/let/cop/bbs/web/EgovBBSAttributeManageControllerPosblAtchFileSizeTest.java
@@ -3,9 +3,11 @@ package egovframework.let.cop.bbs.web;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.egovframe.rte.fdl.property.EgovPropertyService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,10 +41,12 @@ class EgovBBSAttributeManageControllerPosblAtchFileSizeTest extends EgovTestAbst
 
 	@Test
 	@DisplayName("게시판마스터 등록·수정이 조회하는 키가 globals.properties 에 선언된 값을 돌려준다")
-	void testPosblAtchFileSizeIsResolvable() throws Exception {
+	void testPosblAtchFileSizeIsResolvable() {
 		final Properties globals = new Properties();
 		try (InputStream inputStream = getClass().getResourceAsStream(GLOBALS)) {
 			globals.load(inputStream);
+		} catch (IOException e) {
+			throw new BaseRuntimeException(e);
 		}
 
 		assertNotNull(globals.getProperty(KEY), GLOBALS + " 에 " + KEY + " 선언이 없다");

--- a/src/test/java/egovframework/let/cop/bbs/web/EgovBBSAttributeManageControllerTestInsertBBSMasterInfTest.java
+++ b/src/test/java/egovframework/let/cop/bbs/web/EgovBBSAttributeManageControllerTestInsertBBSMasterInfTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.junit.jupiter.api.Test;
 
 import egovframework.test.EgovTestAbstractSpringMvc;
@@ -25,10 +26,11 @@ class EgovBBSAttributeManageControllerTestInsertBBSMasterInfTest extends EgovTes
 	/**
 	 * 신규 게시판 마스터 정보를 등록한다.
 	 * 
+	 * @throws BaseRuntimeException
 	 * @throws Exception
 	 */
 	@Test
-	void test() throws Exception {
+	void test() throws BaseRuntimeException, Exception {
 		// given
 
 		// when

--- a/src/test/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageControllerTestRegistActorTest.java
+++ b/src/test/java/egovframework/let/cop/smt/sim/web/EgovIndvdlSchdulManageControllerTestRegistActorTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MvcResult;
@@ -31,10 +32,11 @@ class EgovIndvdlSchdulManageControllerTestRegistActorTest extends EgovTestAbstra
 	/**
 	 * 서버 검증에 걸려 등록 폼으로 되돌아갈 때 폼이 필요로 하는 목록이 모델에 남아 있어야 한다.
 	 *
+	 * @throws BaseRuntimeException
 	 * @throws Exception
 	 */
 	@Test
-	void test() throws Exception {
+	void test() throws BaseRuntimeException, Exception {
 		// given
 		final LoginVO loginVO = new LoginVO();
 		loginVO.setId("TEST1");

--- a/src/test/java/egovframework/test/EgovMapperTypeHandlerTest.java
+++ b/src/test/java/egovframework/test/EgovMapperTypeHandlerTest.java
@@ -10,6 +10,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
+import org.egovframe.rte.fdl.cmmn.exception.BaseRuntimeException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.SqlSessionFactoryBean;
@@ -58,7 +59,7 @@ class EgovMapperTypeHandlerTest {
 		return dbTypes;
 	}
 
-	private void buildSqlSessionFactory(String dbType) throws Exception {
+	private void buildSqlSessionFactory(String dbType) throws BaseRuntimeException, Exception {
 		PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
 
 		SqlSessionFactoryBean sqlSessionFactoryBean = new SqlSessionFactoryBean();


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

## 개요

메인, 달력, 로그인 및 파일 처리 코드에 남아 있는 포괄적인
`throws Exception` 선언을 제거하고 예외 처리 방식을 구체화합니다.

## 주요 변경 사항

- 메인·달력·로그인 컨트롤러와 서비스의 불필요한 `throws Exception` 제거
- 달력 서비스 인터페이스와 구현체의 예외 선언 일치
- 파일 업로드·다운로드·조회 중 발생하는 `IOException`을
  `BaseRuntimeException`으로 변환
- 존재하지 않거나 일반 파일이 아닌 다운로드 대상에
  `BaseRuntimeException` 적용
- 파일 암복호화 및 비밀번호 해시 생성 과정의 검사 예외를
  `BaseRuntimeException`으로 변환
- 관련 테스트 메서드의 예외 선언 및 import 정리
- 사용하지 않는 로거, 검증 애너테이션 및 페이지네이션 import 제거

## 변경 범위

- 운영 코드 13개 파일
- 테스트 코드 6개 파일
- 총 19개 파일
- 129줄 추가, 128줄 삭제

## 검증

다음 환경에서 clean 컴파일을 확인했습니다.

- Java: JDK 17.0.17+10
- Maven: 3.9.9
- 로컬 저장소: `D:\eGovCI-5.0.0-Windows-64bit.m2\repository`
- 명령: `mvn -Dmaven.repo.local=... -DskipTests=false clean test`
- 결과: `BUILD SUCCESS`
- 메인 소스 101개 및 테스트 소스 13개 컴파일 성공

> `pom.xml`의 Surefire 설정에 `<skipTests>true</skipTests>`가 직접 지정되어
> 있어 테스트 실행 단계는 생략되었습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

http://localhost:8080/egovframe-template-simple

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
